### PR TITLE
Feature/itdev 34780 visual confirmation

### DIFF
--- a/coldfront/plugins/qumulo/templates/allocation.html
+++ b/coldfront/plugins/qumulo/templates/allocation.html
@@ -9,6 +9,9 @@ Create Allocation
 
 {% block content %}
 <div>
+  <div class="alert alert-warning" role="alert">
+    This allocation is marked as pending, please do not update until the status changes.
+  </div>
   <form method="post" id="allocation_form">
     {% csrf_token %}
     {{ form | crispy }}

--- a/coldfront/plugins/qumulo/templates/allocation.html
+++ b/coldfront/plugins/qumulo/templates/allocation.html
@@ -14,6 +14,7 @@ Create Allocation
     This allocation is marked as pending, please do not update until the status changes.
   </div>
   {% endif %}
+  {{ status_allocation }}
   <form method="post" id="allocation_form">
     {% csrf_token %}
     {{ form | crispy }}

--- a/coldfront/plugins/qumulo/templates/allocation.html
+++ b/coldfront/plugins/qumulo/templates/allocation.html
@@ -9,7 +9,7 @@ Create Allocation
 
 {% block content %}
 <div>
-  {% if is_pending == False %}
+  {% if is_pending == None %}
   <div class="alert alert-warning" role="alert">
     This allocation is marked as pending, please do not update until the status changes.
   </div>

--- a/coldfront/plugins/qumulo/templates/allocation.html
+++ b/coldfront/plugins/qumulo/templates/allocation.html
@@ -9,9 +9,11 @@ Create Allocation
 
 {% block content %}
 <div>
+  {% if is_pending == True %}
   <div class="alert alert-warning" role="alert">
     This allocation is marked as pending, please do not update until the status changes.
   </div>
+  {% endif %}
   <form method="post" id="allocation_form">
     {% csrf_token %}
     {{ form | crispy }}

--- a/coldfront/plugins/qumulo/templates/allocation.html
+++ b/coldfront/plugins/qumulo/templates/allocation.html
@@ -9,7 +9,7 @@ Create Allocation
 
 {% block content %}
 <div>
-  {% if is_pending == None %}
+  {% if is_pending == True %}
   <div class="alert alert-warning" role="alert">
     This allocation is marked as pending, please do not update until the status changes.
   </div>

--- a/coldfront/plugins/qumulo/templates/allocation.html
+++ b/coldfront/plugins/qumulo/templates/allocation.html
@@ -14,10 +14,10 @@ Create Allocation
     This allocation is marked as pending, please do not update until the status changes.
   </div>
   {% endif %}
-  {{ status_allocation }}
   <form method="post" id="allocation_form">
     {% csrf_token %}
     {{ form | crispy }}
+    {{ status_allocation }}
     <div class="d-flex justify-content-end">
       <button type="submit" class="btn btn-primary mr-2" id="allocation_form_submit">Submit</button>
       <button type="reset" class="btn btn-primary">Reset</button>

--- a/coldfront/plugins/qumulo/templates/allocation.html
+++ b/coldfront/plugins/qumulo/templates/allocation.html
@@ -9,7 +9,7 @@ Create Allocation
 
 {% block content %}
 <div>
-  {% if is_pending == True %}
+  {% if is_pending == False %}
   <div class="alert alert-warning" role="alert">
     This allocation is marked as pending, please do not update until the status changes.
   </div>

--- a/coldfront/plugins/qumulo/views/allocation_view.py
+++ b/coldfront/plugins/qumulo/views/allocation_view.py
@@ -32,7 +32,7 @@ class AllocationView(LoginRequiredMixin, FormView):
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
-        form_data = context.form.cleaned_data
+        form_data = context["form"].cleaned_data
         user = self.request.user
         new_allocation = AllocationView.create_new_allocation(form_data, user)
         alloc_status = new_allocation.get("allocation").status.name

--- a/coldfront/plugins/qumulo/views/allocation_view.py
+++ b/coldfront/plugins/qumulo/views/allocation_view.py
@@ -43,6 +43,7 @@ class AllocationView(LoginRequiredMixin, FormView):
                 pending_status = False
             context["is_pending"] = pending_status
         context["status_allocation"] = self.new_allocation
+        context["alloc_form"] = context.form
         return context
 
     def get_form_kwargs(self):

--- a/coldfront/plugins/qumulo/views/allocation_view.py
+++ b/coldfront/plugins/qumulo/views/allocation_view.py
@@ -32,8 +32,8 @@ class AllocationView(LoginRequiredMixin, FormView):
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
-        context["form_title"] = "Update Allocation"
-        context["is_pending"] = Allocation
+
+        context["is_pending"] = self.is_pending
         return context
 
     def get_form_kwargs(self):
@@ -60,6 +60,7 @@ class AllocationView(LoginRequiredMixin, FormView):
             form_data, user, parent_allocation
         )
         self.success_id = new_allocation.get("allocation").id
+        self.is_pending = True
 
         return super().form_valid(form)
 

--- a/coldfront/plugins/qumulo/views/allocation_view.py
+++ b/coldfront/plugins/qumulo/views/allocation_view.py
@@ -42,7 +42,7 @@ class AllocationView(LoginRequiredMixin, FormView):
             else:
                 pending_status = False
             context["is_pending"] = pending_status
-        context["status_allocation"] = self.success_id
+        context["status_allocation"] = context_allocation
         context["alloc_form"] = context.form
         return context
 

--- a/coldfront/plugins/qumulo/views/allocation_view.py
+++ b/coldfront/plugins/qumulo/views/allocation_view.py
@@ -33,8 +33,9 @@ class AllocationView(LoginRequiredMixin, FormView):
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
+        context_allocation = self.new_allocation
         if self.new_allocation != None:
-            alloc_status = self.new_allocation.get("allocation").status.name
+            alloc_status = context_allocation.get("allocation").status.name
             if alloc_status == "Pending":
                 is_pending = True
             else:

--- a/coldfront/plugins/qumulo/views/allocation_view.py
+++ b/coldfront/plugins/qumulo/views/allocation_view.py
@@ -35,7 +35,6 @@ class AllocationView(LoginRequiredMixin, FormView):
         context = super().get_context_data(**kwargs)
         if self.new_allocation != None:
             alloc_status = self.new_allocation.get("allocation").status.name
-            print(alloc_status)
             if alloc_status == "Pending":
                 is_pending = True
             else:

--- a/coldfront/plugins/qumulo/views/allocation_view.py
+++ b/coldfront/plugins/qumulo/views/allocation_view.py
@@ -42,7 +42,7 @@ class AllocationView(LoginRequiredMixin, FormView):
             else:
                 pending_status = False
             context["is_pending"] = pending_status
-        context["status_allocation"] = self.new_allocation
+        context["status_allocation"] = self.success_id
         context["alloc_form"] = context.form
         return context
 

--- a/coldfront/plugins/qumulo/views/allocation_view.py
+++ b/coldfront/plugins/qumulo/views/allocation_view.py
@@ -32,8 +32,11 @@ class AllocationView(LoginRequiredMixin, FormView):
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
-
-        context["is_pending"] = False
+        if self.status.name == "Pending":
+            pending_status = True
+        else:
+            pending_status = False
+        context["is_pending"] = pending_status
         return context
 
     def get_form_kwargs(self):

--- a/coldfront/plugins/qumulo/views/allocation_view.py
+++ b/coldfront/plugins/qumulo/views/allocation_view.py
@@ -29,13 +29,11 @@ from pathlib import PurePath
 class AllocationView(LoginRequiredMixin, FormView):
     form_class = AllocationForm
     template_name = "allocation.html"
+    new_allocation = None
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
-        form_data = context["form"]
-        user = self.request.user
-        new_allocation = AllocationView.create_new_allocation(form_data, user)
-        alloc_status = new_allocation.get("allocation").status.name
+        alloc_status = self.new_allocation.get("allocation").status.name
         if alloc_status == "Pending":
             is_pending = True
         else:
@@ -63,10 +61,10 @@ class AllocationView(LoginRequiredMixin, FormView):
             absolute_path = f"/{storage_root}/{storage_filesystem_path}"
         validate_filesystem_path_unique(absolute_path)
 
-        new_allocation = AllocationView.create_new_allocation(
+        self.new_allocation = AllocationView.create_new_allocation(
             form_data, user, parent_allocation
         )
-        self.success_id = new_allocation.get("allocation").id
+        self.success_id = self.new_allocation.get("allocation").id
 
         return super().form_valid(form)
 

--- a/coldfront/plugins/qumulo/views/allocation_view.py
+++ b/coldfront/plugins/qumulo/views/allocation_view.py
@@ -1,7 +1,7 @@
 from django.shortcuts import get_object_or_404
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.views.generic.edit import FormView
-from django.urls import reverse_lazy
+from django.urls import reverse_lazy, reverse
 
 from typing import Union
 
@@ -54,6 +54,13 @@ class AllocationView(LoginRequiredMixin, FormView):
         AllocationView.create_new_allocation(form_data, user, parent_allocation)
 
         return super().form_valid(form)
+
+    def get_success_url(self):
+
+        return reverse(
+            "coldfront_plugin_qumulo:updateAllocation",
+            kwargs={"allocation_id": self.success_id},
+        )
 
     @staticmethod
     def create_new_allocation(

--- a/coldfront/plugins/qumulo/views/allocation_view.py
+++ b/coldfront/plugins/qumulo/views/allocation_view.py
@@ -51,7 +51,10 @@ class AllocationView(LoginRequiredMixin, FormView):
             absolute_path = f"/{storage_root}/{storage_filesystem_path}"
         validate_filesystem_path_unique(absolute_path)
 
-        AllocationView.create_new_allocation(form_data, user, parent_allocation)
+        new_allocation = AllocationView.create_new_allocation(
+            form_data, user, parent_allocation
+        )
+        self.success_id = new_allocation.get("allocation").id
 
         return super().form_valid(form)
 

--- a/coldfront/plugins/qumulo/views/allocation_view.py
+++ b/coldfront/plugins/qumulo/views/allocation_view.py
@@ -29,7 +29,12 @@ from pathlib import PurePath
 class AllocationView(LoginRequiredMixin, FormView):
     form_class = AllocationForm
     template_name = "allocation.html"
-    success_url = reverse_lazy("home")
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context["form_title"] = "Update Allocation"
+        context["is_pending"] = Allocation
+        return context
 
     def get_form_kwargs(self):
         kwargs = super(AllocationView, self).get_form_kwargs()

--- a/coldfront/plugins/qumulo/views/allocation_view.py
+++ b/coldfront/plugins/qumulo/views/allocation_view.py
@@ -35,6 +35,7 @@ class AllocationView(LoginRequiredMixin, FormView):
         context = super().get_context_data(**kwargs)
         if self.new_allocation != None:
             alloc_status = self.new_allocation.get("allocation").status.name
+            print(alloc_status)
             if alloc_status == "Pending":
                 is_pending = True
             else:

--- a/coldfront/plugins/qumulo/views/allocation_view.py
+++ b/coldfront/plugins/qumulo/views/allocation_view.py
@@ -41,6 +41,7 @@ class AllocationView(LoginRequiredMixin, FormView):
             else:
                 pending_status = False
             context["is_pending"] = pending_status
+        context["status_allocation"] = alloc_status
         return context
 
     def get_form_kwargs(self):

--- a/coldfront/plugins/qumulo/views/allocation_view.py
+++ b/coldfront/plugins/qumulo/views/allocation_view.py
@@ -32,7 +32,7 @@ class AllocationView(LoginRequiredMixin, FormView):
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
-        form_data = context["form"].cleaned_data
+        form_data = context["form"]
         user = self.request.user
         new_allocation = AllocationView.create_new_allocation(form_data, user)
         alloc_status = new_allocation.get("allocation").status.name

--- a/coldfront/plugins/qumulo/views/allocation_view.py
+++ b/coldfront/plugins/qumulo/views/allocation_view.py
@@ -33,12 +33,13 @@ class AllocationView(LoginRequiredMixin, FormView):
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
-        alloc_status = self.new_allocation.get("allocation").status.name
-        if alloc_status == "Pending":
-            is_pending = True
-        else:
-            is_pending = False
-        context["is_pending"] = is_pending
+        if self.new_allocation != None:
+            alloc_status = self.new_allocation.get("allocation").status.name
+            if alloc_status == "Pending":
+                is_pending = True
+            else:
+                is_pending = False
+            context["is_pending"] = is_pending
         return context
 
     def get_form_kwargs(self):

--- a/coldfront/plugins/qumulo/views/allocation_view.py
+++ b/coldfront/plugins/qumulo/views/allocation_view.py
@@ -31,21 +31,6 @@ class AllocationView(LoginRequiredMixin, FormView):
     template_name = "allocation.html"
     new_allocation = None
 
-    def get_context_data(self, **kwargs):
-        context = super().get_context_data(**kwargs)
-        context_allocation = self.new_allocation
-        alloc_status = " "
-        if self.new_allocation != None:
-            alloc_status = context_allocation.get("allocation").status.name
-            if alloc_status == "Pending":
-                pending_status = True
-            else:
-                pending_status = False
-            context["is_pending"] = pending_status
-        context["status_allocation"] = context_allocation
-        context["alloc_form"] = context.form
-        return context
-
     def get_form_kwargs(self):
         kwargs = super(AllocationView, self).get_form_kwargs()
         kwargs["user_id"] = self.request.user.id

--- a/coldfront/plugins/qumulo/views/allocation_view.py
+++ b/coldfront/plugins/qumulo/views/allocation_view.py
@@ -33,7 +33,7 @@ class AllocationView(LoginRequiredMixin, FormView):
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
 
-        context["is_pending"] = True
+        context["is_pending"] = False
         return context
 
     def get_form_kwargs(self):

--- a/coldfront/plugins/qumulo/views/allocation_view.py
+++ b/coldfront/plugins/qumulo/views/allocation_view.py
@@ -42,7 +42,7 @@ class AllocationView(LoginRequiredMixin, FormView):
             else:
                 pending_status = False
             context["is_pending"] = pending_status
-        context["status_allocation"] = context_allocation
+        context["status_allocation"] = self.new_allocation
         return context
 
     def get_form_kwargs(self):

--- a/coldfront/plugins/qumulo/views/allocation_view.py
+++ b/coldfront/plugins/qumulo/views/allocation_view.py
@@ -30,6 +30,19 @@ class AllocationView(LoginRequiredMixin, FormView):
     form_class = AllocationForm
     template_name = "allocation.html"
 
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        form_data = context.form.cleaned_data
+        user = self.request.user
+        new_allocation = AllocationView.create_new_allocation(form_data, user)
+        alloc_status = new_allocation.get("allocation").status.name
+        if alloc_status == "Pending":
+            is_pending = True
+        else:
+            is_pending = False
+        context["is_pending"] = is_pending
+        return context
+
     def get_form_kwargs(self):
         kwargs = super(AllocationView, self).get_form_kwargs()
         kwargs["user_id"] = self.request.user.id
@@ -54,15 +67,8 @@ class AllocationView(LoginRequiredMixin, FormView):
             form_data, user, parent_allocation
         )
         self.success_id = new_allocation.get("allocation").id
-        self.is_pending = True
 
         return super().form_valid(form)
-
-    def get_context_data(self, **kwargs):
-        context = super().get_context_data(**kwargs)
-
-        context["is_pending"] = self.success_id
-        return context
 
     def get_success_url(self):
 

--- a/coldfront/plugins/qumulo/views/allocation_view.py
+++ b/coldfront/plugins/qumulo/views/allocation_view.py
@@ -34,6 +34,7 @@ class AllocationView(LoginRequiredMixin, FormView):
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         context_allocation = self.new_allocation
+        alloc_status = " "
         if self.new_allocation != None:
             alloc_status = context_allocation.get("allocation").status.name
             if alloc_status == "Pending":

--- a/coldfront/plugins/qumulo/views/allocation_view.py
+++ b/coldfront/plugins/qumulo/views/allocation_view.py
@@ -58,7 +58,7 @@ class AllocationView(LoginRequiredMixin, FormView):
     def get_success_url(self):
 
         return reverse(
-            "coldfront_plugin_qumulo:updateAllocation",
+            "qumulo:updateAllocation",
             kwargs={"allocation_id": self.success_id},
         )
 

--- a/coldfront/plugins/qumulo/views/allocation_view.py
+++ b/coldfront/plugins/qumulo/views/allocation_view.py
@@ -42,7 +42,7 @@ class AllocationView(LoginRequiredMixin, FormView):
             else:
                 pending_status = False
             context["is_pending"] = pending_status
-        context["status_allocation"] = alloc_status
+        context["status_allocation"] = context_allocation
         return context
 
     def get_form_kwargs(self):

--- a/coldfront/plugins/qumulo/views/allocation_view.py
+++ b/coldfront/plugins/qumulo/views/allocation_view.py
@@ -61,7 +61,7 @@ class AllocationView(LoginRequiredMixin, FormView):
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
 
-        context["is_pending"] = self.is_pending
+        context["is_pending"] = self.success_id
         return context
 
     def get_success_url(self):

--- a/coldfront/plugins/qumulo/views/allocation_view.py
+++ b/coldfront/plugins/qumulo/views/allocation_view.py
@@ -37,10 +37,10 @@ class AllocationView(LoginRequiredMixin, FormView):
         if self.new_allocation != None:
             alloc_status = context_allocation.get("allocation").status.name
             if alloc_status == "Pending":
-                is_pending = True
+                pending_status = True
             else:
-                is_pending = False
-            context["is_pending"] = is_pending
+                pending_status = False
+            context["is_pending"] = pending_status
         return context
 
     def get_form_kwargs(self):

--- a/coldfront/plugins/qumulo/views/allocation_view.py
+++ b/coldfront/plugins/qumulo/views/allocation_view.py
@@ -33,7 +33,7 @@ class AllocationView(LoginRequiredMixin, FormView):
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
 
-        context["is_pending"] = self.is_pending
+        context["is_pending"] = True
         return context
 
     def get_form_kwargs(self):

--- a/coldfront/plugins/qumulo/views/allocation_view.py
+++ b/coldfront/plugins/qumulo/views/allocation_view.py
@@ -30,15 +30,6 @@ class AllocationView(LoginRequiredMixin, FormView):
     form_class = AllocationForm
     template_name = "allocation.html"
 
-    def get_context_data(self, **kwargs):
-        context = super().get_context_data(**kwargs)
-        if self.status.name == "Pending":
-            pending_status = True
-        else:
-            pending_status = False
-        context["is_pending"] = pending_status
-        return context
-
     def get_form_kwargs(self):
         kwargs = super(AllocationView, self).get_form_kwargs()
         kwargs["user_id"] = self.request.user.id
@@ -66,6 +57,12 @@ class AllocationView(LoginRequiredMixin, FormView):
         self.is_pending = True
 
         return super().form_valid(form)
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+
+        context["is_pending"] = self.is_pending
+        return context
 
     def get_success_url(self):
 

--- a/coldfront/plugins/qumulo/views/update_allocation_view.py
+++ b/coldfront/plugins/qumulo/views/update_allocation_view.py
@@ -26,17 +26,16 @@ class UpdateAllocationView(AllocationView):
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
-        context_allocation = self.new_allocation
-        alloc_status = " "
-        if self.new_allocation != None:
-            alloc_status = context_allocation.get("allocation").status.name
-            if alloc_status == "Pending":
-                pending_status = True
-            else:
-                pending_status = False
-            context["is_pending"] = pending_status
-        context["status_allocation"] = context_allocation
-        context["alloc_form"] = context.form
+        allocation_id = self.kwargs.get("allocation_id")
+        allocation = Allocation.objects.get(pk=allocation_id)
+        alloc_status = allocation.get("allocation").status.name
+
+        if alloc_status == "Pending":
+            pending_status = True
+        else:
+            pending_status = False
+        context["is_pending"] = pending_status
+
         return context
 
     def get_form_kwargs(self):

--- a/coldfront/plugins/qumulo/views/update_allocation_view.py
+++ b/coldfront/plugins/qumulo/views/update_allocation_view.py
@@ -28,7 +28,7 @@ class UpdateAllocationView(AllocationView):
         context = super().get_context_data(**kwargs)
         allocation_id = self.kwargs.get("allocation_id")
         allocation = Allocation.objects.get(pk=allocation_id)
-        alloc_status = allocation.get("allocation").status.name
+        alloc_status = allocation.status.name
 
         if alloc_status == "Pending":
             pending_status = True

--- a/coldfront/plugins/qumulo/views/update_allocation_view.py
+++ b/coldfront/plugins/qumulo/views/update_allocation_view.py
@@ -24,6 +24,21 @@ class UpdateAllocationView(AllocationView):
     template_name = "allocation.html"
     success_url = reverse_lazy("home")
 
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context_allocation = self.new_allocation
+        alloc_status = " "
+        if self.new_allocation != None:
+            alloc_status = context_allocation.get("allocation").status.name
+            if alloc_status == "Pending":
+                pending_status = True
+            else:
+                pending_status = False
+            context["is_pending"] = pending_status
+        context["status_allocation"] = context_allocation
+        context["alloc_form"] = context.form
+        return context
+
     def get_form_kwargs(self):
         kwargs = super(UpdateAllocationView, self).get_form_kwargs()
         kwargs["user_id"] = self.request.user.id


### PR DESCRIPTION
This PR adds a visual confirmation to show that an allocation has been created. When a new allocation has been created the page will redirect to the Update Allocation view. Tf the allocation status is pending, then a yellow banner will display at the top of the screen that says "This allocation is marked as pending, please do not update until the status changes."

**TEST INSTRUCTIONS**
Case One:
1. Navigate to the create allocation page
2. Create an allocation
3. Confirm that the page redirects to the Update Allocation form with a yellow warning banner at the top

Case Two:
1. Navigate to Admin -> All Allocations
2. Select an allocation and change the status to "Pending"
3. Navigate to View All Allocation
4. Filter by status "Pending"
5. Click on the allocation ID of an allocation with the "Pending" status
6. Confirm that the page redirects to the Update Allocation form with a yellow warning banner at the top

<img width="1725" alt="Screenshot 2024-09-23 at 1 29 35 PM" src="https://github.com/user-attachments/assets/6740e806-2a39-494e-b8c8-28e9fc646a70">

