### PR TITLE
Feature/itdev 35291 user readme access acl

### DIFF
--- a/coldfront/plugins/qumulo/utils/aces_manager.py
+++ b/coldfront/plugins/qumulo/utils/aces_manager.py
@@ -83,7 +83,7 @@ class AcesManager(object):
         },
         {
             "type": "ALLOWED",
-            "trustee": {"name": "everyone", "domain": "README.txt"},
+            "trustee": {"name": "Everyone"},
             "rights": [
                 "READ",
             ],

--- a/coldfront/plugins/qumulo/utils/aces_manager.py
+++ b/coldfront/plugins/qumulo/utils/aces_manager.py
@@ -81,41 +81,11 @@ class AcesManager(object):
                 "WRITE_EA",
             ],
         },
-    ]
-    readme_aces = [
         {
-            "flags": ["OBJECT_INHERIT"],
             "type": "ALLOWED",
-            "trustee": {
-                "name": "rw_groupname",
-                "domain": "README",
-            },
+            "trustee": {"name": "everyone", "domain": "README"},
             "rights": [
                 "READ",
-                "SYNCHRONIZE",
-                "READ_ACL",
-                "READ_ATTR",
-                "READ_EA",
-                "ADD_FILE",
-                "ADD_SUBDIR",
-                "DELETE_CHILD",
-                "WRITE_ATTR",
-                "WRITE_EA",
-            ],
-        },
-        {
-            "flags": ["OBJECT_INHERIT"],
-            "type": "ALLOWED",
-            "trustee": {
-                "name": "ro_groupname",
-                "domain": "README",
-            },
-            "rights": [
-                "READ",
-                "SYNCHRONIZE",
-                "READ_ACL",
-                "READ_ATTR",
-                "READ_EA",
             ],
         },
     ]

--- a/coldfront/plugins/qumulo/utils/aces_manager.py
+++ b/coldfront/plugins/qumulo/utils/aces_manager.py
@@ -83,7 +83,7 @@ class AcesManager(object):
         },
         {
             "type": "ALLOWED",
-            "trustee": {"name": "everyone", "domain": "README"},
+            "trustee": {"name": "everyone", "domain": "README.txt"},
             "rights": [
                 "READ",
             ],

--- a/coldfront/plugins/qumulo/utils/aces_manager.py
+++ b/coldfront/plugins/qumulo/utils/aces_manager.py
@@ -7,7 +7,7 @@ class AcesManager(object):
             "aces": [],
         }
 
-    # readme access is now in default aces variable
+    # readme access is now in the default aces variable
     default_aces = [
         {
             "flags": ["CONTAINER_INHERIT"],

--- a/coldfront/plugins/qumulo/utils/aces_manager.py
+++ b/coldfront/plugins/qumulo/utils/aces_manager.py
@@ -82,6 +82,43 @@ class AcesManager(object):
             ],
         },
     ]
+    readme_aces = [
+        {
+            "flags": ["OBJECT_INHERIT"],
+            "type": "ALLOWED",
+            "trustee": {
+                "name": "rw_groupname",
+                "domain": "README",
+            },
+            "rights": [
+                "READ",
+                "SYNCHRONIZE",
+                "READ_ACL",
+                "READ_ATTR",
+                "READ_EA",
+                "ADD_FILE",
+                "ADD_SUBDIR",
+                "DELETE_CHILD",
+                "WRITE_ATTR",
+                "WRITE_EA",
+            ],
+        },
+        {
+            "flags": ["OBJECT_INHERIT"],
+            "type": "ALLOWED",
+            "trustee": {
+                "name": "ro_groupname",
+                "domain": "README",
+            },
+            "rights": [
+                "READ",
+                "SYNCHRONIZE",
+                "READ_ACL",
+                "READ_ATTR",
+                "READ_EA",
+            ],
+        },
+    ]
 
     @staticmethod
     def get_allocation_aces(rw_groupname: str, ro_groupname: str):

--- a/coldfront/plugins/qumulo/utils/aces_manager.py
+++ b/coldfront/plugins/qumulo/utils/aces_manager.py
@@ -82,6 +82,7 @@ class AcesManager(object):
             ],
         },
         {
+            "flags": [],
             "type": "ALLOWED",
             "trustee": {"name": "Everyone"},
             "rights": [

--- a/coldfront/plugins/qumulo/utils/aces_manager.py
+++ b/coldfront/plugins/qumulo/utils/aces_manager.py
@@ -7,7 +7,7 @@ class AcesManager(object):
             "aces": [],
         }
 
-    # readme access is now in default aces
+    # readme access is now in default aces variable
     default_aces = [
         {
             "flags": ["CONTAINER_INHERIT"],

--- a/coldfront/plugins/qumulo/utils/aces_manager.py
+++ b/coldfront/plugins/qumulo/utils/aces_manager.py
@@ -7,7 +7,7 @@ class AcesManager(object):
             "aces": [],
         }
 
-    # readme access now in default aces
+    # readme access is now in default aces
     default_aces = [
         {
             "flags": ["CONTAINER_INHERIT"],

--- a/coldfront/plugins/qumulo/utils/aces_manager.py
+++ b/coldfront/plugins/qumulo/utils/aces_manager.py
@@ -7,6 +7,7 @@ class AcesManager(object):
             "aces": [],
         }
 
+    # readme access now in default aces
     default_aces = [
         {
             "flags": ["CONTAINER_INHERIT"],

--- a/coldfront/plugins/qumulo/utils/qumulo_api.py
+++ b/coldfront/plugins/qumulo/utils/qumulo_api.py
@@ -77,7 +77,7 @@ class QumuloAPI:
         fs_path = f"{path}/{file_name}"
         acl = AcesManager().get_base_acl()
 
-        aces = default_aces
+        aces = AcesManager.readme_aces
         acl["aces"] = aces
 
         self.rc.fs.set_acl_v2(path=fs_path, acl=acl)

--- a/coldfront/plugins/qumulo/utils/qumulo_api.py
+++ b/coldfront/plugins/qumulo/utils/qumulo_api.py
@@ -77,7 +77,7 @@ class QumuloAPI:
         fs_path = f"{path}/{file_name}"
         acl = AcesManager().get_base_acl()
 
-        aces = AcesManager.readme_aces
+        aces = AcesManager.default_aces
         acl["aces"] = aces
 
         self.rc.fs.set_acl_v2(path=fs_path, acl=acl)

--- a/coldfront/plugins/qumulo/utils/qumulo_api.py
+++ b/coldfront/plugins/qumulo/utils/qumulo_api.py
@@ -76,10 +76,10 @@ class QumuloAPI:
             self.rc.fs.write_file(id_=readme_meta["id"], data_file=arf)
         fs_path = f"{path}/{file_name}"
         acl = AcesManager().get_base_acl()
-        
-        aces = #build_aces
-        acl['aces'] = aces
-        
+
+        aces = default_aces
+        acl["aces"] = aces
+
         self.rc.fs.set_acl_v2(path=fs_path, acl=acl)
 
     def create_protocol(self, export_path: str, fs_path: str, name: str, protocol: str):

--- a/coldfront/plugins/qumulo/utils/qumulo_api.py
+++ b/coldfront/plugins/qumulo/utils/qumulo_api.py
@@ -74,6 +74,13 @@ class QumuloAPI:
         readme_meta = self.rc.fs.create_file(dir_path=path, name=file_name)
         with open("/etc/allocation-README.txt", "r") as arf:
             self.rc.fs.write_file(id_=readme_meta["id"], data_file=arf)
+        fs_path = f"{path}/{file_name}"
+        acl = AcesManager().get_base_acl()
+        
+        aces = #build_aces
+        acl['aces'] = aces
+        
+        self.rc.fs.set_acl_v2(path=fs_path, acl=acl)
 
     def create_protocol(self, export_path: str, fs_path: str, name: str, protocol: str):
         if name == None:


### PR DESCRIPTION
Read-only access given to anyone who can access the README.txt in an allocation.

Testing Instructions

- Pull ITDEV-35291 and build locally (making sure that the .env file targets storage2-dev)
- Launch coldfront (local) and create a two new allocations. (add ad-ris-qa as a rw user for one and add ad-ris-qa as a wo user for the other)
- retrieve ad-ris-qa log in information from pass (pass shared-user-accounts/RIS-SVC-QA)
- ssh ad-ris-qa@compute-dev-exec-2.ris.wustl.edu
- cd /storage2-dev/fs1/allocation_name
- vim README.txt then :w inside vim window
- verify that "E45: 'readonly' option is set (add ! to override)" displays in the lower left corner of the vim window