### PR TITLE
Fix Redirect to Parent Allocation + Sub-Alloc becoming Updates

### DIFF
--- a/coldfront/plugins/qumulo/views/create_sub_allocation_view.py
+++ b/coldfront/plugins/qumulo/views/create_sub_allocation_view.py
@@ -6,6 +6,7 @@ from coldfront.core.allocation.models import (
     AllocationAttribute,
 )
 from coldfront.plugins.qumulo.forms import CreateSubAllocationForm
+from coldfront.plugins.qumulo.views.allocation_view import AllocationView
 from coldfront.plugins.qumulo.views.update_allocation_view import UpdateAllocationView
 from coldfront.plugins.qumulo.utils.acl_allocations import AclAllocations
 from coldfront.plugins.qumulo.utils.active_directory_api import ActiveDirectoryAPI
@@ -63,4 +64,6 @@ class CreateSubAllocationView(UpdateAllocationView):
     def form_valid(self, form: CreateSubAllocationForm):
         allocation_id = self.kwargs.get("allocation_id")
         parent_allocation = Allocation.objects.get(pk=allocation_id)
-        return super().form_valid(form, parent_allocation=parent_allocation)
+        return super(AllocationView, self).form_valid(
+            form, parent_allocation=parent_allocation
+        )

--- a/coldfront/plugins/qumulo/views/create_sub_allocation_view.py
+++ b/coldfront/plugins/qumulo/views/create_sub_allocation_view.py
@@ -6,10 +6,7 @@ from coldfront.core.allocation.models import (
     AllocationAttribute,
 )
 from coldfront.plugins.qumulo.forms import CreateSubAllocationForm
-from coldfront.plugins.qumulo.views.allocation_view import AllocationView
 from coldfront.plugins.qumulo.views.update_allocation_view import UpdateAllocationView
-from coldfront.plugins.qumulo.utils.acl_allocations import AclAllocations
-from coldfront.plugins.qumulo.utils.active_directory_api import ActiveDirectoryAPI
 
 
 class CreateSubAllocationView(UpdateAllocationView):
@@ -64,6 +61,6 @@ class CreateSubAllocationView(UpdateAllocationView):
     def form_valid(self, form: CreateSubAllocationForm):
         allocation_id = self.kwargs.get("allocation_id")
         parent_allocation = Allocation.objects.get(pk=allocation_id)
-        return super(AllocationView, self).form_valid(
+        return super(UpdateAllocationView, self).form_valid(
             form, parent_allocation=parent_allocation
         )

--- a/coldfront/plugins/qumulo/views/create_sub_allocation_view.py
+++ b/coldfront/plugins/qumulo/views/create_sub_allocation_view.py
@@ -61,6 +61,11 @@ class CreateSubAllocationView(UpdateAllocationView):
     def form_valid(self, form: CreateSubAllocationForm):
         allocation_id = self.kwargs.get("allocation_id")
         parent_allocation = Allocation.objects.get(pk=allocation_id)
+        # jprew - skipping update form_valid because *that* skips
+        # the base class form_valid
+
+        # TODO - remove this logic from form_valid; it doesn't belong
+        # in the view layer
         return super(UpdateAllocationView, self).form_valid(
             form, parent_allocation=parent_allocation
         )


### PR DESCRIPTION
Previously, the data associated with a sub-allocation was being applied to the parent allocation as a change request + the user was redirected to the parent allocation Update page.

This PR fixes that behavior.