### PR TITLE
Remove "EVERYONE" Ace from ACL

### DIFF
--- a/coldfront/plugins/qumulo/utils/acl_allocations.py
+++ b/coldfront/plugins/qumulo/utils/acl_allocations.py
@@ -231,13 +231,10 @@ class AclAllocations:
 
         if is_base_allocation:
             aces.extend(AcesManager.default_copy())
-            aces.extend(AcesManager.everyone_ace)
             acl["aces"] = AcesManager.filter_duplicates(aces)
             qumulo_api.rc.fs.set_acl_v2(acl=acl, path=fs_path)
             aces.extend(AcesManager.get_allocation_aces(rw_groupname, ro_groupname))
-            acl["aces"] = AcesManager.filter_duplicates(
-                AcesManager.remove_everyone_aces(aces)
-            )
+            acl["aces"] = AcesManager.filter_duplicates(aces)
             qumulo_api.rc.fs.set_acl_v2(acl=acl, path=f"{fs_path}/Active")
         else:
             for extension in [


### PR DESCRIPTION
Test plan:

- Create allocation and sub-allocations as needed; activate when ACL AD groups are ready.
    - verify that allocation directory does not have "EVERYONE" ace:
       `nfs4_getfacl <allocation_path> | grep EVERYONE` should not print any results
-  Navigate to "Update Allocation" form for the allocation, perform "Reset ACLs" operation.
    - When reset completes, verify that no "EVERYONE" aces are present on the directory with the same command as above. 