### PR TITLE
add command

### DIFF
--- a/coldfront/plugins/qumulo/management/commands/fix_add_missing_access_allocation.py
+++ b/coldfront/plugins/qumulo/management/commands/fix_add_missing_access_allocation.py
@@ -1,0 +1,36 @@
+from coldfront.core.allocation.models import Allocation, AllocationStatusChoice
+from coldfront.core.resource.models import Resource
+
+from django.core.management.base import BaseCommand
+
+from coldfront.plugins.qumulo.views.allocation_view import AllocationView
+
+
+class Command(BaseCommand):
+    def add_arguments(self, parser):
+        parser.add_argument("allocation_pk", type=int)
+
+    def handle(self, *args, **options):
+        allocation_pk = options["allocation_pk"]
+
+        print(f"Creating RO Access Allocation for {allocation_pk}")
+
+        try:
+            allocation = Allocation.objects.get(pk=allocation_pk)
+        except Exception as e:
+            print(f"Allocation with pk {allocation_pk} not found")
+            return
+
+        access_data = {"name": "RO Users", "resource": "ro", "users": []}
+
+        access_allocation = AllocationView.create_access_allocation(
+            access_data=access_data,
+            project=allocation.project,
+            storage_name=allocation.get_attribute(name="storage_name"),
+            storage_allocation=allocation,
+        )
+
+        access_allocation.status = AllocationStatusChoice.objects.get(name="Active")
+        access_allocation.save()
+
+        print(f"Access Allocation created for {allocation_pk}")


### PR DESCRIPTION
https://washu.atlassian.net/browse/ITDEV-35949

Test:
- Create and Activate an Allocation.  Note the Allocation ID
- Go into the admin view and delete ONLY the "RO Users" Allocation associated with it
- Connect to the server via kubectl and run `kubectl exec -it -n coldfront deployment/coldfront-deployment -- coldfront fix_add_missing_access_allocation {allocation_pk}`
- Verify there is a new RO Users allocation
