### PR TITLE
temporary email mod

### DIFF
--- a/coldfront/core/utils/mail.py
+++ b/coldfront/core/utils/mail.py
@@ -37,10 +37,10 @@ def send_email(subject, body, sender, receiver_list, cc=[]):
     """Helper function for sending emails"""
 
     # TEMPORARY: only sends emails to app-eng while we get a picture of the email system
-    original_recipients = receiver_list.copy()
-    body = f"Original Recipients: {original_recipients}\n\n{body}"
+    body = f"Original Recipients: {receiver_list}\n\nCC'dL {cc}\n\n{body}"
 
     receiver_list = ["ris-appeng@gowustl.onmicrosoft.com"]
+    cc = []
     # END TEMPORARY
 
     if not EMAIL_ENABLED:

--- a/coldfront/core/utils/mail.py
+++ b/coldfront/core/utils/mail.py
@@ -36,6 +36,13 @@ def allocation_email_recipients(allocation_obj):
 def send_email(subject, body, sender, receiver_list, cc=[]):
     """Helper function for sending emails"""
 
+    # TEMPORARY: only sends emails to app-eng while we get a picture of the email system
+    original_recipients = receiver_list.copy()
+    body = f"Original Recipients: {original_recipients}\n\n{body}"
+
+    receiver_list = ["ris-appeng@gowustl.onmicrosoft.com"]
+    # END TEMPORARY
+
     if not EMAIL_ENABLED:
         return
 


### PR DESCRIPTION
Reroutes all emails to us and prefixes a list of the original recipients onto the body.  QA testing to come when available.