### PR TITLE
ITDEV-36145 - Handling non-existent attributes

### DIFF
--- a/coldfront/plugins/qumulo/static/migration_mappings/mock_itsm_response_body_service_provision_found_missing_contacts.json
+++ b/coldfront/plugins/qumulo/static/migration_mappings/mock_itsm_response_body_service_provision_found_missing_contacts.json
@@ -1,0 +1,302 @@
+{
+    "attribute": [
+        "id",
+        "service_id",
+        "name",
+        "sponsor",
+        "department_number",
+        "department_name",
+        "funding_number",
+        "billing_contact",
+        "technical_contact",
+        "secure",
+        "service_desk_ticket_number",
+        "audit",
+        "creation_timestamp",
+        "billing_startdate",
+        "status",
+        "sponsor_department_number",
+        "fileset_name",
+        "fileset_alias",
+        "exempt",
+        "service_rate_category",
+        "comment",
+        "billing_cycle",
+        "subsidized",
+        "quota",
+        "allow_nonfaculty",
+        "acl_group_members",
+        "who",
+        "parent_id",
+        "is_condo_group",
+        "sla"
+    ],
+    "metadata": [
+        {
+            "column": "id",
+            "display_name": "Id",
+            "show": true,
+            "table_alias": "a",
+            "type": "_num"
+        },
+        {
+            "column": "service_id",
+            "display_name": "Service Id",
+            "show": true,
+            "table_alias": "a",
+            "type": "service"
+        },
+        {
+            "column": "name",
+            "display_name": "Name",
+            "show": true,
+            "table_alias": "a",
+            "type": "_string"
+        },
+        {
+            "column": "sponsor",
+            "display_name": "Sponsor",
+            "show": true,
+            "table_alias": "a",
+            "editable": true,
+            "type": "_string"
+        },
+        {
+            "type": "department",
+            "table_alias": "a",
+            "column": "department_number",
+            "display_name": "Department",
+            "editable": true,
+            "show": true
+        },
+        {
+            "type": "department",
+            "table_alias": "d",
+            "column": "name",
+            "display_name": "Department",
+            "show": true
+        },
+        {
+            "column": "funding_number",
+            "display_name": "Funding Number",
+            "show": true,
+            "table_alias": "a",
+            "editable": true,
+            "type": "_string"
+        },
+        {
+            "column": "billing_contact",
+            "display_name": "Billing Contacts (comma separated)",
+            "show": true,
+            "table_alias": "a",
+            "editable": true,
+            "type": "_string"
+        },
+        {
+            "column": "technical_contact",
+            "display_name": "Technical Contact",
+            "show": true,
+            "table_alias": "a",
+            "editable": true,
+            "type": "_string"
+        },
+        {
+            "column": "secure",
+            "display_name": "Secure",
+            "show": true,
+            "table_alias": "a",
+            "type": "_boolean"
+        },
+        {
+            "column": "service_desk_ticket_number",
+            "display_name": "Service Desk Ticket Number",
+            "show": true,
+            "table_alias": "a",
+            "editable": true,
+            "type": "_string"
+        },
+        {
+            "column": "audit",
+            "display_name": "Audit",
+            "show": true,
+            "table_alias": "a",
+            "editable": true,
+            "type": "_string"
+        },
+        {
+            "column": "creation_timestamp",
+            "display_name": "Creation Timestamp",
+            "show": true,
+            "table_alias": "a",
+            "type": "_timestamp"
+        },
+        {
+            "column": "billing_startdate",
+            "display_name": "Billing Startdate",
+            "show": true,
+            "table_alias": "a",
+            "type": "_date"
+        },
+        {
+            "column": "status",
+            "display_name": "Status",
+            "show": true,
+            "table_alias": "a",
+            "editable": true,
+            "type": "_string"
+        },
+        {
+            "column": "sponsor_department_number",
+            "display_name": "Sponsor Department Number",
+            "show": true,
+            "table_alias": "a",
+            "type": "_num",
+            "editable": true
+        },
+        {
+            "column": "fileset_name",
+            "display_name": "Fileset Name",
+            "show": true,
+            "table_alias": "a",
+            "type": "_string"
+        },
+        {
+            "column": "fileset_alias",
+            "display_name": "Fileset Alias",
+            "show": true,
+            "table_alias": "a",
+            "type": "_string",
+            "editable": true
+        },
+        {
+            "column": "exempt",
+            "display_name": "Exempt from Billing",
+            "show": true,
+            "table_alias": "a",
+            "editable": true,
+            "type": "_boolean"
+        },
+        {
+            "type": "service_rate_category",
+            "table_alias": "a",
+            "column": "service_rate_category",
+            "display_name": "Service Rate Category",
+            "editable": true,
+            "show": true
+        },
+        {
+            "column": "comment",
+            "display_name": "Comment",
+            "show": true,
+            "table_alias": "a",
+            "editable": true,
+            "type": "_string"
+        },
+        {
+            "column": "billing_cycle",
+            "display_name": "Billing Cycle",
+            "show": true,
+            "table_alias": "a",
+            "editable": true,
+            "type": "billing_cycle"
+        },
+        {
+            "column": "subsidized",
+            "display_name": "Subsidized",
+            "show": true,
+            "table_alias": "a",
+            "editable": true,
+            "type": "_boolean"
+        },
+        {
+            "column": "quota",
+            "display_name": "Quota",
+            "show": true,
+            "table_alias": "a",
+            "editable": true,
+            "type": "_string"
+        },
+        {
+            "column": "allow_nonfaculty",
+            "display_name": "Allow Non-faculty",
+            "show": true,
+            "table_alias": "a",
+            "type": "_boolean"
+        },
+        {
+            "column": "acl_group_members",
+            "display_name": "ACL Group Members",
+            "show": true,
+            "table_alias": "a",
+            "editable": true,
+            "type": "_string"
+        },
+        {
+            "column": "who",
+            "display_name": "Last Edited by",
+            "show": true,
+            "table_alias": "a",
+            "editable": false,
+            "type": "_string"
+        },
+        {
+            "column": "parent_id",
+            "display_name": "Condo Group",
+            "show": true,
+            "table_alias": "a",
+            "editable": true,
+            "type": "collection_select"
+        },
+        {
+            "column": "is_condo_group",
+            "display_name": "Is Condo Group",
+            "show": true,
+            "table_alias": "a",
+            "type": "_boolean"
+        },
+        {
+            "column": "sla",
+            "display_name": "SLA",
+            "show": true,
+            "table_alias": "a",
+            "type": "_string"
+        }
+    ],
+    "data": [
+        {
+            "id": 774,
+            "service_id": 1,
+            "name": "/vol/rdcw-fs1/jin810",
+            "sponsor": "mocker_missing_contacts",
+            "department_number": "CH00409",
+            "department_name": "Genetics",
+            "funding_number": "CC0004259",
+            "billing_contact": "",
+            "technical_contact": "",
+            "secure": false,
+            "service_desk_ticket_number": "ITSD-2222",
+            "audit": null,
+            "creation_timestamp": "2020-04-16T00: 00: 00.000Z",
+            "billing_startdate": "2020-04-15T00: 00: 00.000Z",
+            "status": "active",
+            "sponsor_department_number": "CH00409",
+            "fileset_name": "mocker_missing_contacts_active",
+            "fileset_alias": "mocker_missing_contacts_active",
+            "exempt": false,
+            "service_rate_category": "subscription",
+            "comment": "{\"afm_cache_enable\":true,\"_jenkins\":\"https://systems-ci.gsc.wustl.edu/job/storage1_allocation/2652\",\"add_archive\":\"true\"}",
+            "billing_cycle": "monthly",
+            "subsidized": true,
+            "quota": "200T",
+            "allow_nonfaculty": null,
+            "acl_group_members": "b.cooper,c.m.choi,fup,jin810,k.mariam,k.prashantkumar,kuangyingyang,shohaibshaffiey,shujuanzhao,spencer.king,WG-amarsheth,WG-fu.po-ying,WG-kareena,WG-kesava,WG-nicholas.diab,yung-chun,w.max",
+            "who": "rpokorne",
+            "parent_id": null,
+            "is_condo_group": false,
+            "sla": null,
+            "_service_provision": 774,
+            "_department": "CH00409"
+        }
+    ],
+    "entity": "service_provision"
+}

--- a/coldfront/plugins/qumulo/tests/services/itsm/test_migrate_to_coldfront.py
+++ b/coldfront/plugins/qumulo/tests/services/itsm/test_migrate_to_coldfront.py
@@ -7,7 +7,6 @@ from unittest import mock
 from coldfront.core.allocation.models import (
     Allocation,
     AllocationAttribute,
-    AllocationAttributeType,
 )
 from coldfront.core.project.models import Project, ProjectAttribute
 from coldfront.plugins.qumulo.services.itsm.migrate_to_coldfront import (

--- a/coldfront/plugins/qumulo/tests/services/itsm/test_migrate_to_coldfront.py
+++ b/coldfront/plugins/qumulo/tests/services/itsm/test_migrate_to_coldfront.py
@@ -4,7 +4,11 @@ from django.test import TestCase
 
 from unittest import mock
 
-from coldfront.core.allocation.models import Allocation, AllocationAttribute
+from coldfront.core.allocation.models import (
+    Allocation,
+    AllocationAttribute,
+    AllocationAttributeType,
+)
 from coldfront.core.project.models import Project, ProjectAttribute
 from coldfront.plugins.qumulo.services.itsm.migrate_to_coldfront import (
     MigrateToColdfront,
@@ -18,6 +22,57 @@ class TestMigrateToColdfront(TestCase):
     def setUp(self) -> None:
         self.migrate = MigrateToColdfront()
         create_allocation_assets()
+        self.expected_allocation_attributes = [
+            ("storage_name", "mocker"),
+            ("storage_quota", "200"),
+            ("storage_protocols", '["smb"]'),
+            ("storage_filesystem_path", "/storage2-dev/fs1/mocker"),
+            ("storage_export_path", "/storage2-dev/fs1/mocker"),
+            ("cost_center", "CC0004259"),
+            ("department_number", "CH00409"),
+            ("service_rate", "subscription"),
+            ("secure", "No"),
+            ("audit", "No"),
+            ("exempt", "No"),
+            ("subsidized", "Yes"),
+            ("billing_contact", "jin810"),
+            ("technical_contact", "jin810"),
+            ("storage_ticket", "ITSD-2222"),
+            ("billing_startdate", "2020-04-15T00: 00: 00.000Z"),
+            ("fileset_name", "mocker_active"),
+            ("fileset_alias", "mocker_active"),
+            (
+                "itsm_comment",
+                '{"afm_cache_enable":true,"_jenkins":"https://systems-ci.gsc.wustl.edu/job/storage1_allocation/2652","add_archive":"true"}',
+            ),
+            ("billing_cycle", "monthly"),
+            ("sla_name", ""),
+        ]
+
+        self.expected_allocation_attributes_missing_contacts = [
+            ("storage_name", "mocker_missing_contacts"),
+            ("storage_quota", "200"),
+            ("storage_protocols", '["smb"]'),
+            ("storage_filesystem_path", "/storage2-dev/fs1/mocker_missing_contacts"),
+            ("storage_export_path", "/storage2-dev/fs1/mocker_missing_contacts"),
+            ("cost_center", "CC0004259"),
+            ("department_number", "CH00409"),
+            ("service_rate", "subscription"),
+            ("secure", "No"),
+            ("audit", "No"),
+            ("exempt", "No"),
+            ("subsidized", "Yes"),
+            ("storage_ticket", "ITSD-2222"),
+            ("billing_startdate", "2020-04-15T00: 00: 00.000Z"),
+            ("fileset_name", "mocker_missing_contacts_active"),
+            ("fileset_alias", "mocker_missing_contacts_active"),
+            (
+                "itsm_comment",
+                '{"afm_cache_enable":true,"_jenkins":"https://systems-ci.gsc.wustl.edu/job/storage1_allocation/2652","add_archive":"true"}',
+            ),
+            ("billing_cycle", "monthly"),
+            ("sla_name", ""),
+        ]
 
     @mock.patch(
         "coldfront.plugins.qumulo.services.itsm.migrate_to_coldfront.ItsmClient"
@@ -42,16 +97,65 @@ class TestMigrateToColdfront(TestCase):
         self.assertDictEqual(
             result, {"allocation_id": 1, "pi_user_id": 1, "project_id": 1}
         )
+
         allocation = Allocation.objects.get(id=result["allocation_id"])
         project = Project.objects.get(id=result["project_id"])
-        allocation_attributes = AllocationAttribute.objects.filter(
-            allocation=result["allocation_id"]
-        )
-        project_attributes = ProjectAttribute.objects.filter(
-            project=result["project_id"]
-        )
-        self.assertEqual(len(allocation_attributes), 21)
-        self.assertEqual(len(project_attributes), 3)
         self.assertEqual(allocation.id, result["allocation_id"])
         self.assertEqual(allocation.project, project)
         self.assertEqual(allocation.project.title, name)
+
+        allocation_attributes = AllocationAttribute.objects.filter(
+            allocation=result["allocation_id"]
+        )
+        allocation_attribute_values = allocation_attributes.values_list(
+            "allocation_attribute_type__name", "value"
+        )
+
+        for attribute_value in self.expected_allocation_attributes:
+            self.assertIn(attribute_value, allocation_attribute_values)
+
+        self.assertEqual(allocation_attributes.count(), 21)
+
+        project_attributes = ProjectAttribute.objects.filter(
+            project=result["project_id"]
+        )
+        self.assertEqual(len(project_attributes), 3)
+
+    @mock.patch(
+        "coldfront.plugins.qumulo.services.itsm.migrate_to_coldfront.ItsmClient"
+    )
+    @mock.patch("coldfront.plugins.qumulo.services.allocation_service.async_task")
+    def test_migrate_to_coldfront_with_contacts_missing(
+        self,
+        mock_async_task: mock.MagicMock,
+        mock_itsm_client: mock.MagicMock,
+    ) -> None:
+        with open(
+            "coldfront/plugins/qumulo/static/migration_mappings/mock_itsm_response_body_service_provision_found_missing_contacts.json",
+            "r",
+        ) as file:
+            mock_response = json.load(file)["data"]
+            itsm_client = mock.MagicMock()
+            itsm_client.get_fs1_allocation_by_fileset_name.return_value = mock_response
+            mock_itsm_client.return_value = itsm_client
+
+        name = "mocker_missing_contacts"
+        result = self.migrate.by_fileset_name(f"{name}_active")
+        allocation = Allocation.objects.get(id=result["allocation_id"])
+        self.assertEqual(allocation.id, result["allocation_id"])
+
+        allocation_attributes = AllocationAttribute.objects.filter(
+            allocation=result["allocation_id"]
+        )
+        allocation_attribute_values = allocation_attributes.values_list(
+            "allocation_attribute_type__name", "value"
+        )
+
+        for attribute_value in self.expected_allocation_attributes_missing_contacts:
+            self.assertIn(attribute_value, allocation_attribute_values)
+
+        self.assertEqual(allocation_attributes.count(), 19)
+        # optional fields with empty or missing values should not create
+        # allocation_attributes on create allocation
+        for value in [("billing_contact", ""), ("technical_contact", "")]:
+            self.assertNotIn(value, allocation_attribute_values)

--- a/coldfront/plugins/qumulo/tests/views/test_update_allocation_view.py
+++ b/coldfront/plugins/qumulo/tests/views/test_update_allocation_view.py
@@ -15,7 +15,6 @@ from coldfront.plugins.qumulo.tests.utils.mock_data import (
 from coldfront.plugins.qumulo.utils.acl_allocations import AclAllocations
 
 from coldfront.core.allocation.models import (
-    Allocation,
     AllocationAttribute,
     AllocationAttributeChangeRequest,
     AllocationAttributeType,

--- a/coldfront/plugins/qumulo/tests/views/test_update_allocation_view.py
+++ b/coldfront/plugins/qumulo/tests/views/test_update_allocation_view.py
@@ -15,6 +15,7 @@ from coldfront.plugins.qumulo.tests.utils.mock_data import (
 from coldfront.plugins.qumulo.utils.acl_allocations import AclAllocations
 
 from coldfront.core.allocation.models import (
+    Allocation,
     AllocationAttribute,
     AllocationAttributeChangeRequest,
     AllocationAttributeType,
@@ -301,6 +302,92 @@ class UpdateAllocationViewTests(TestCase):
             )
 
             self.assertEqual(change_request.new_value, new_val)
+
+    def test_attribute_change_request_creation_with_optional_attributes(
+        self, mock_ActiveDirectoryAPI: MagicMock, mock_async_task: MagicMock
+    ):
+        form_data_missing_contacts = {
+            "storage_filesystem_path": "foo_missing",
+            "storage_export_path": "bar_missing",
+            "storage_ticket": "ITSD-54321",
+            "storage_name": "baz",
+            "storage_quota": 7,
+            "protocols": ["smb"],
+            "rw_users": ["test"],
+            "ro_users": [],
+            "cost_center": "Internation Monetary Fund",
+            "department_number": "Time Travel Services",
+            "service_rate": "consumption",
+        }
+
+        storage_allocation_missing_contacts = create_allocation(
+            self.project, self.user, form_data_missing_contacts
+        )
+
+        attributes_to_check = [
+            "cost_center",
+            "department_number",
+            "technical_contact",
+            "billing_contact",
+            "service_rate",
+            "storage_ticket",
+            "storage_quota",
+        ]
+        original_values = AllocationAttribute.objects.filter(
+            allocation_attribute_type__name__in=attributes_to_check,
+            allocation=storage_allocation_missing_contacts,
+        ).values_list("allocation_attribute_type__name", "value")
+
+        allocation_change_request = AllocationChangeRequest.objects.create(
+            allocation=storage_allocation_missing_contacts,
+            status=AllocationChangeStatusChoice.objects.get(name="Pending"),
+            justification="updating",
+            notes="updating",
+            end_date_extension=10,
+        )
+
+        for name, value in original_values:
+            UpdateAllocationView._handle_attribute_change(
+                allocation=storage_allocation_missing_contacts,
+                allocation_change_request=allocation_change_request,
+                attribute_name=name,
+                form_value=value,
+            )
+
+        for name, value in [
+            ("billing_contact", "new_billing_contact"),
+            ("technical_contact", "new_tech_contact"),
+        ]:
+            UpdateAllocationView._handle_attribute_change(
+                allocation=storage_allocation_missing_contacts,
+                allocation_change_request=allocation_change_request,
+                attribute_name=name,
+                form_value=value,
+            )
+
+            change_request = AllocationAttributeChangeRequest.objects.get(
+                allocation_attribute=AllocationAttribute.objects.get(
+                    allocation_attribute_type__name=name,
+                    allocation=storage_allocation_missing_contacts,
+                ),
+                allocation_change_request=allocation_change_request,
+            )
+
+            self.assertEqual(change_request.new_value, value)
+
+        request = RequestFactory().post("/irrelevant")
+        form = UpdateAllocationForm(
+            data=form_data_missing_contacts, user_id=self.user.id
+        )
+        form_data_missing_contacts["billing_contact"] = "new_billing_contact"
+        form_data_missing_contacts["technical_contact"] = "new_tech_contact"
+        form.cleaned_data = form_data_missing_contacts
+        form.clean()
+        view = UpdateAllocationView(form=form, user_id=self.user.id)
+        view.setup(request, allocation_id=storage_allocation_missing_contacts.id)
+        view.success_id = 1
+
+        self.assertTrue(view.form_valid(form))
 
     def test_update_allocation_form_and_view_valid(
         self, mock_ActiveDirectoryAPI: MagicMock, mock_async_task: MagicMock

--- a/coldfront/plugins/qumulo/views/update_allocation_view.py
+++ b/coldfront/plugins/qumulo/views/update_allocation_view.py
@@ -191,23 +191,15 @@ class UpdateAllocationView(AllocationView):
         form_value: Union[str, int],
     ) -> None:
         # some attributes are optional and so may not exist
-        try:
-            attribute = AllocationAttribute.objects.get(
-                allocation_attribute_type=AllocationAttributeType.objects.get(
-                    name=attribute_name
-                ),
-                allocation=allocation,
-            )
-        except AllocationAttribute.DoesNotExist:
-            # create the attribute if it doesn't exist, but do it with an empty
-            # value to the change request workflow can proceed
-            attribute = AllocationAttribute.objects.create(
-                allocation=allocation,
-                allocation_attribute_type=AllocationAttributeType.objects.get(
-                    name=attribute_name
-                ),
-                value="",
-            )
+        # if they don't, we want to create them with an empty
+        # value so the change request flow will work
+        attribute, _ = AllocationAttribute.objects.get_or_create(
+            allocation_attribute_type=AllocationAttributeType.objects.get(
+                name=attribute_name
+            ),
+            allocation=allocation,
+            defaults={"value": ""},
+        )
 
         # storage quota needs to be compared as an integer
         comparand = int(attribute.value) if type(form_value) is int else attribute.value

--- a/coldfront/plugins/qumulo/views/update_allocation_view.py
+++ b/coldfront/plugins/qumulo/views/update_allocation_view.py
@@ -190,12 +190,24 @@ class UpdateAllocationView(AllocationView):
         attribute_name: str,
         form_value: Union[str, int],
     ) -> None:
-        attribute = AllocationAttribute.objects.get(
-            allocation_attribute_type=AllocationAttributeType.objects.get(
-                name=attribute_name
-            ),
-            allocation=allocation,
-        )
+        # some attributes are optional and so may not exist
+        try:
+            attribute = AllocationAttribute.objects.get(
+                allocation_attribute_type=AllocationAttributeType.objects.get(
+                    name=attribute_name
+                ),
+                allocation=allocation,
+            )
+        except AllocationAttribute.DoesNotExist:
+            # create the attribute if it doesn't exist, but do it with an empty
+            # value to the change request workflow can proceed
+            attribute = AllocationAttribute.objects.create(
+                allocation=allocation,
+                allocation_attribute_type=AllocationAttributeType.objects.get(
+                    name=attribute_name
+                ),
+                value="",
+            )
 
         # storage quota needs to be compared as an integer
         comparand = int(attribute.value) if type(form_value) is int else attribute.value


### PR DESCRIPTION
This will allow non-existent attributes to be handled through the attribute change request workflow by creating a placeholder `AllocationAttribute` with an empty value to start with.

Test Instructions:

1. Identify an ITSM allocation without a `technical_contact` (or `billing_contact`).
2. Use the metadata migration tool to migrate that allocation
3. Confirm that no `technical_contact` or `billing_contact` `AllocationAttribute` records exist
4. On the Update Allocation page, change the `technical_contact (or `billing_contact`) and confirm a change request is created
5. Approve the change request
6. Repeat steps 1 to 3, but confirm you can change *other* fields, such as adding a new user, without adding a new `technical_contact` or `billing_contact`