### PR TITLE
type change to datetime field

### DIFF
--- a/coldfront/plugins/qumulo/forms.py
+++ b/coldfront/plugins/qumulo/forms.py
@@ -230,7 +230,7 @@ class UpdateAllocationForm(AllocationForm):
         self.fields["storage_filesystem_path"].validators = []
         self.fields["storage_name"].validators = []
 
-        self.fields["prepaid_expiration"] = forms.DateField(
+        self.fields["prepaid_expiration"] = forms.DateTimeField(
             help_text="Allocation is paid until this date",
             label="Prepaid Expiration Date",
             required=False,


### PR DESCRIPTION
This PR changes the Prepaid Expiration Date field type from Date to DateTime. This ensures that the correct validators are used to prevent an invalid date message. 