### PR TITLE
ITDEV- 36453 - productionize parallel scripts

### DIFF
--- a/parallel_reset_commands/acl_spec_builder.py
+++ b/parallel_reset_commands/acl_spec_builder.py
@@ -33,7 +33,7 @@ class ACL_SpecBuilder:
                 with open("templates/root_spec_sub_alloc_entry_template.txt", "r") as sub_alloc_template_file:
                     sub_alloc_template = sub_alloc_template_file.read()
                     sub_alloc_spec_entry = sub_alloc_template.replace("<SUB_ALLOC>", sub_alloc_name)
-                    root_template = root_template + sub_alloc_spec_entry
+                    root_template = root_template + "\n" + sub_alloc_spec_entry
             self.root_spec = root_template.replace("<ALLOC>", alloc_name)
         
         # need a spec for the Active folder
@@ -45,7 +45,7 @@ class ACL_SpecBuilder:
                 with open("templates/active_spec_sub_alloc_entry_template.txt", "r") as sub_alloc_template_file:
                     sub_alloc_template = sub_alloc_template_file.read()
                     sub_alloc_spec_entry = sub_alloc_template.replace("<SUB_ALLOC>", sub_alloc_name)
-                    active_template = active_template + sub_alloc_spec_entry + "\n"
+                    active_template = active_template + "\n" + sub_alloc_spec_entry
             self.active_spec = active_template.replace("<ALLOC>", alloc_name)
 
         # need a spec for folders/files *OUTSIDE* sub-allocations

--- a/parallel_reset_commands/acl_spec_builder.py
+++ b/parallel_reset_commands/acl_spec_builder.py
@@ -1,0 +1,124 @@
+from typing import List
+
+import os
+
+from constants import STORAGE_2_PREFIX
+
+class ACL_SpecBuilder:
+    def __init__(self):
+        self.base_folder_spec = ""
+        self.base_file_spec = ""
+
+        self.root_spec = ""
+        self.active_spec = ""
+
+        self.sub_alloc_file_specs = dict()
+        self.sub_alloc_folder_specs = dict()
+        self.sub_alloc_root_specs = dict()
+
+        self.allocation_name = ""
+        self.sub_alloc_names = []
+        # jprew - TODO - need to update the get_spec_by_path method to use
+        # these
+        
+    
+    def build_specs(self, alloc_name: str, sub_alloc_names: List[str]):
+        self.allocation_name = alloc_name
+        self.sub_allocation_names = sub_alloc_names
+        # need a spec for the root of the allocation
+        with open("templates/root_spec_template.txt", "r") as root_template_file:
+            root_template = root_template_file.read()
+            for sub_alloc_name in sub_alloc_names:
+                # need a spec for the sub-allocation
+                with open("templates/root_spec_sub_alloc_entry_template.txt", "r") as sub_alloc_template_file:
+                    sub_alloc_template = sub_alloc_template_file.read()
+                    sub_alloc_spec_entry = sub_alloc_template.replace("<SUB_ALLOC>", sub_alloc_name)
+                    root_template = root_template + sub_alloc_spec_entry
+            self.root_spec = root_template.replace("<ALLOC>", alloc_name)
+        
+        # need a spec for the Active folder
+        with open("templates/active_spec_template.txt", "r") as active_template_file:
+            active_template = active_template_file.read()
+            
+            for sub_alloc_name in sub_alloc_names:
+                # need a spec for the sub-allocation
+                with open("templates/active_spec_sub_alloc_entry_template.txt", "r") as sub_alloc_template_file:
+                    sub_alloc_template = sub_alloc_template_file.read()
+                    sub_alloc_spec_entry = sub_alloc_template.replace("<SUB_ALLOC>", sub_alloc_name)
+                    active_template = active_template + sub_alloc_spec_entry
+            self.active_spec = active_template.replace("<ALLOC>", alloc_name)
+
+        # need a spec for folders/files *OUTSIDE* sub-allocations
+        with open("templates/base_folder_spec_template.txt", "r") as base_folder_template_file:
+            base_folder_template = base_folder_template_file.read()
+            self.base_folder_spec = base_folder_template.replace("<ALLOC>", alloc_name)
+
+        with open("templates/base_file_spec_template.txt", "r") as base_file_template_file:
+            base_file_template = base_file_template_file.read()
+            self.base_file_spec = base_file_template.replace("<ALLOC>", alloc_name)
+        
+        # need a spec for *each* of the sub-allocations at the sub-allocation's root,
+        # for folders beneath root, and for files
+        # store it with the sub-allocation name as the key
+        with open("templates/sub_alloc_root_spec_template.txt", "r") as sub_alloc_root_template_file:
+            sub_alloc_root_template = sub_alloc_root_template_file.read()
+            for sub_alloc_name in sub_alloc_names:
+                self.sub_alloc_root_specs[sub_alloc_name] = sub_alloc_root_template.replace("<SUB_ALLOC>", sub_alloc_name).replace("<ALLOC>", alloc_name)
+        with open("templates/sub_alloc_folder_spec_template.txt", "r") as sub_alloc_folder_template_file:
+            sub_alloc_folder_template = sub_alloc_folder_template_file.read()
+            for sub_alloc_name in sub_alloc_names:
+                self.sub_alloc_folder_specs[sub_alloc_name] = sub_alloc_folder_template.replace("<SUB_ALLOC>", sub_alloc_name).replace("<ALLOC>", alloc_name)
+        with open("templates/sub_alloc_file_spec_template.txt", "r") as sub_alloc_file_template_file:
+            sub_alloc_file_template = sub_alloc_file_template_file.read()
+            for sub_alloc_name in sub_alloc_names:
+                self.sub_alloc_file_specs[sub_alloc_name] = sub_alloc_file_template.replace("<SUB_ALLOC>", sub_alloc_name).replace("<ALLOC>", alloc_name)
+
+    def get_root_spec(self):
+        return self.root_spec
+    
+    def get_active_spec(self):
+        return self.active_spec
+    
+    def get_base_folder_spec(self):
+        return self.base_folder_spec
+    
+    def get_base_file_spec(self):
+        return self.base_file_spec
+    
+    def get_sub_alloc_root_spec(self, sub_alloc_name: str):
+        return self.sub_alloc_root_specs.get(sub_alloc_name, "")
+
+    def get_sub_alloc_folder_spec(self, sub_alloc_name: str):
+        return self.sub_alloc_folder_specs.get(sub_alloc_name, "")
+    
+    def get_sub_alloc_file_spec(self, sub_alloc_name: str):
+        return self.sub_alloc_file_specs.get(sub_alloc_name, "")
+    
+    def get_spec_by_path(self, target: str, item_type: str):
+        # jprew - TODO - this is a stub
+        allocation_root = f"{STORAGE_2_PREFIX}/{self.allocation_name}"
+        allocation_root_active = f"{allocation_root}/Active"
+        if os.path.samefile(allocation_root, target):
+            return self.get_root_spec()
+        elif os.path.samefile(allocation_root_active, target):
+            return self.get_active_spec()
+
+        # check if target *is* one of the sub_alloc roots
+        sub_alloc_roots = []
+        for name in self.sub_alloc_names:
+            path = os.path.join(f"{allocation_root}/Active/", name.strip())
+            sub_alloc_roots.append(str(path))
+
+        for sub_alloc_root, sub_alloc_name in zip(sub_alloc_roots, self.sub_alloc_names):
+            if os.path.samefile(sub_alloc_root, target):
+                return self.get_sub_alloc_root_spec(sub_alloc_name)
+            elif target.startswith(sub_alloc_root + os.sep):
+                if item_type == "directory":
+                    return self.get_sub_alloc_folder_spec(sub_alloc_name)
+                else:
+                    return self.get_sub_alloc_file_spec(sub_alloc_name)
+        
+        if item_type == "directory":
+            return self.get_base_folder_spec()
+        else:
+            return self.get_base_file_spec()

--- a/parallel_reset_commands/acl_spec_builder.py
+++ b/parallel_reset_commands/acl_spec_builder.py
@@ -24,7 +24,7 @@ class ACL_SpecBuilder:
     
     def build_specs(self, alloc_name: str, sub_alloc_names: List[str]):
         self.allocation_name = alloc_name
-        self.sub_allocation_names = sub_alloc_names
+        self.sub_alloc_names = sub_alloc_names
         # need a spec for the root of the allocation
         with open("templates/root_spec_template.txt", "r") as root_template_file:
             root_template = root_template_file.read()

--- a/parallel_reset_commands/acl_spec_builder.py
+++ b/parallel_reset_commands/acl_spec_builder.py
@@ -45,7 +45,7 @@ class ACL_SpecBuilder:
                 with open("templates/active_spec_sub_alloc_entry_template.txt", "r") as sub_alloc_template_file:
                     sub_alloc_template = sub_alloc_template_file.read()
                     sub_alloc_spec_entry = sub_alloc_template.replace("<SUB_ALLOC>", sub_alloc_name)
-                    active_template = active_template + sub_alloc_spec_entry
+                    active_template = active_template + sub_alloc_spec_entry + "\n"
             self.active_spec = active_template.replace("<ALLOC>", alloc_name)
 
         # need a spec for folders/files *OUTSIDE* sub-allocations

--- a/parallel_reset_commands/argument_parser.py
+++ b/parallel_reset_commands/argument_parser.py
@@ -98,13 +98,12 @@ class ArgumentParser:
             raise ValueError("Number of workers per walk must be a positive integer.")
         self.num_workers_per_walk = args.num_workers_per_walk
 
-        if os.path.isabs(args.log_dir):
-            if not os.path.exists(args.log_dir):
-                os.makedirs(args.log_dir)
-            self.log_dir = args.log_dir
-        else:
-            current_dir = os.path.dirname(os.path.abspath(__file__))
-            self.log_dir = os.path.join(current_dir, args.log_dir)
+        candidate_dir = args.log_dir
+        if not os.path.isabs(candidate_dir):
+            candidate_dir = os.path.join(os.getcwd(), args.log_dir)
+        if not os.path.exists(candidate_dir):
+            os.makedirs(candidate_dir)
+        self.log_dir = candidate_dir
         
         if os.listdir(self.log_dir):
             raise ValueError(f"Log directory is not empty: {self.log_dir}")

--- a/parallel_reset_commands/argument_parser.py
+++ b/parallel_reset_commands/argument_parser.py
@@ -100,7 +100,7 @@ class ArgumentParser:
 
         if os.path.isabs(args.log_dir):
             if not os.path.exists(args.log_dir):
-                raise ValueError(f"Absolute log directory does not exist: {args.log_dir}")
+                os.makedirs(args.log_dir)
             self.log_dir = args.log_dir
         else:
             current_dir = os.path.dirname(os.path.abspath(__file__))

--- a/parallel_reset_commands/argument_parser.py
+++ b/parallel_reset_commands/argument_parser.py
@@ -1,0 +1,146 @@
+import os
+
+from constants import STORAGE_2_PREFIX
+
+class ArgumentParser:
+
+    def __init__(self):
+        self.perform_reset = False
+        self.allocation_name = ""
+        self.allocation_root = ""
+        self.num_walkers = 0
+        self.num_workers_per_walk = 0
+        self.target_dir = ""
+        self.sub_allocations = []
+        self.log_dir = ""
+    
+    def get_perform_reset(self):
+        return self.perform_reset
+    
+    def get_allocation_name(self):
+        return self.allocation_name
+    
+    def get_allocation_root(self):
+        return self.allocation_root
+
+    def get_num_walkers(self):
+        return self.num_walkers
+    
+    def get_num_workers_per_walk(self):
+        return self.num_workers_per_walk
+    
+    def get_target_dir(self):
+        return self.target_dir
+    
+    def get_sub_allocations(self):
+        return self.sub_allocations
+    
+    def get_log_dir(self):
+        return self.log_dir
+    
+    def retrieve_args(self):
+        print("Retrieving args")
+
+        def validate_perform_reset(value):
+            if value.lower() not in ['y', 'n']:
+                print("Invalid input. Please enter 'y' or 'n'.")
+                return False
+            return True
+        perform_reset_y_n = self._retrieve_arg('perform reset', "Perform reset? (y/n): ", validate_perform_reset)
+        self.perform_reset = (perform_reset_y_n == 'y')
+
+        # first, retrieve a file and confirm it exists in 
+        # a passed-in validator
+        # enter the root directory of the allocation
+        def validate_allocation_root(value):
+            # check that there is only a single part after the prefix
+            # and that the path exists
+            if not value.startswith(STORAGE_2_PREFIX):
+                print(f"Root path must look like '{STORAGE_2_PREFIX}<ROOT>'.")
+                return False
+            # check that there is only a single part after the prefix
+            allocation_root_name = value.replace(STORAGE_2_PREFIX, '').strip('/')
+            if '/' in allocation_root_name:
+                print(f"Root path must look like '{STORAGE_2_PREFIX}<ROOT>'.")
+                return False
+            if not (os.path.exists(value) and os.path.isdir(value)):
+                print(f"Root path does not exist: {value}")
+                return False
+            return True
+        allocation_root = self._retrieve_arg('allocation root', "Enter the root directory of the allocation: ", validate_allocation_root)
+        # get the target directory (where to start the walk)
+        target_dir = self._retrieve_arg('target directory', "Enter the target directory: ", lambda x: os.path.exists(x) and os.path.isdir(x) and x.startswith(allocation_root))
+        
+        def validate_sub_allocation_names(value, allocation_root):
+            if value == '':
+                return True
+            sub_alloc_names = value.split(',')
+            sub_alloc_paths = []
+            for name in sub_alloc_names:
+                path = os.path.join(f"{allocation_root}/Active/", name.strip())
+                sub_alloc_paths.append(path)
+            return all(os.path.exists(path) and os.path.isdir(path) for path in sub_alloc_paths)
+        sub_allocations = self._retrieve_arg('sub-allocation names', "Enter the sub-allocation names (comma-separated): ", lambda x: validate_sub_allocation_names(x, allocation_root)).split(',')
+        if len(sub_allocations) == 1 and sub_allocations[0] == '':
+            sub_allocations = []
+
+        # enter the number of walkers
+        def _validate_num_walkers(value):
+            try:
+                value = int(value)
+                if value <= 0:
+                    print("Number of walkers must be a positive integer.")
+                    return False
+                return True
+            except ValueError:
+                print("Invalid input. Please enter a valid number.")
+                return False
+        
+        num_walkers = int(self._retrieve_arg('number of walkers', "Enter the number of walkers: ", _validate_num_walkers))
+        # enter the number of workers
+        def _validate_num_workers_per_walk(value):
+            try:
+                value = int(value)
+                if value <= 0:
+                    print("Number of workers per walk must be a positive integer.")
+                    return False
+                return True
+            except ValueError:
+                print("Invalid input. Please enter a valid number.")
+                return False
+        num_workers_per_walk = int(self._retrieve_arg('number of workers per walk', "Enter the number of worker threads per walk: ", _validate_num_workers_per_walk))
+
+        def _validate_log_dir(value):
+            if os.path.isabs(value):
+                if not os.path.exists(value):
+                    print(f"Absolute log directory does not exist: {value}")
+                    return False
+            # else the path will be built
+            return True
+
+        log_dir = self._retrieve_arg('log directory', "Enter the log directory: ",_validate_log_dir)
+
+        if os.path.isabs(log_dir):
+            self.log_dir = log_dir
+        else:
+            # build the log directory under wherever this script is running
+
+            current_dir = os.path.dirname(os.path.abspath(__file__))
+            self.log_dir = os.path.join(current_dir, log_dir)
+        
+        self.allocation_root = allocation_root
+        self.allocation_name = allocation_root.replace(STORAGE_2_PREFIX, '').strip('/')
+        self.target_dir = target_dir
+        self.sub_allocations = sub_allocations
+        self.num_walkers = num_walkers
+        self.num_workers_per_walk = num_workers_per_walk
+
+    def _retrieve_arg(self, arg_name, prompt, validator=None):
+        while True:
+            value = input(prompt)
+            if validator and not validator(value):
+                print(f"Invalid value for {arg_name}. Please try again.")
+                continue
+            # self.args[arg_name] = value
+            break
+        return value

--- a/parallel_reset_commands/constants.py
+++ b/parallel_reset_commands/constants.py
@@ -1,0 +1,2 @@
+STORAGE_2_PREFIX = "/storage2/fs1"
+BATCH_SIZE=10000

--- a/parallel_reset_commands/directory_walker.py
+++ b/parallel_reset_commands/directory_walker.py
@@ -1,0 +1,66 @@
+import os
+
+from collections import deque
+
+def walk_recursive_from_target(directory, verbose: bool = False):
+    # jprew - NOTE - the walk seems to be missing the top level directory
+    # need to fix
+    if verbose:
+        print(f'Processing directory starting at: {directory}')
+    
+    yield directory, 'directory'
+    for root, dirs, files in os.walk(directory):
+        if verbose:
+            print(f'Processing directory: {root}')
+            print(f"Root contains: {dirs} {files}")
+        for name in files:
+            next_path = os.path.join(root, name)
+            # print(f"Yielding file: {next_path}")
+            yield next_path, 'file'
+        for name in dirs:
+            next_path = os.path.join(root, name)
+            # print(f"Yielding directory: {next_path}")
+            yield next_path, 'directory'
+
+def walk_to_max_depth(target, max_depth):
+    q = deque([target])
+    depth_at_target = target.count(os.sep)
+    yield target, 'directory'
+    while q:
+        current_dir = q.pop()
+        with os.scandir(current_dir) as it:
+            for entry in it:
+                file_dir_type = 'file'
+                if entry.is_dir():
+                    # check if it is less than max_depth + depth_at_target
+                    # if so, add to processing queue
+                    if entry.path.count(os.sep) <= (max_depth + depth_at_target):
+                        q.append(entry.path)
+                        file_dir_type = 'directory'
+                yield entry.path, file_dir_type
+
+def find_depth_for_target_dirs(root, sub_dir_threshold):
+    count = 0
+    dirnames_found = []
+    current_level_dirs = [root]
+    reached_threshold = False
+    depth = 0
+    while not reached_threshold:
+        next_level_dirs = []
+        for dir in current_level_dirs:
+            with os.scandir(dir) as it:
+                for entry in it:
+                    if entry.is_dir():
+                        next_level_dirs.append(entry.path)
+        if len(next_level_dirs) == 0:
+            break
+        current_level_dirs = next_level_dirs
+        if len(current_level_dirs) >= sub_dir_threshold:
+            reached_threshold = True
+            break
+        depth += 1
+    if reached_threshold:
+        count = len(current_level_dirs)
+        dirnames_found = current_level_dirs
+        return depth, count, dirnames_found
+    return None

--- a/parallel_reset_commands/directory_walker.py
+++ b/parallel_reset_commands/directory_walker.py
@@ -32,11 +32,11 @@ def walk_to_max_depth(target, max_depth):
             for entry in it:
                 file_dir_type = 'file'
                 if entry.is_dir():
+                    file_dir_type = 'directory'
                     # check if it is less than max_depth + depth_at_target
                     # if so, add to processing queue
                     if entry.path.count(os.sep) <= (max_depth + depth_at_target):
                         q.append(entry.path)
-                        file_dir_type = 'directory'
                 yield entry.path, file_dir_type
 
 def find_depth_for_target_dirs(root, sub_dir_threshold):

--- a/parallel_reset_commands/parallel_acl_controller.py
+++ b/parallel_reset_commands/parallel_acl_controller.py
@@ -102,6 +102,13 @@ def process_acls_recursive(perform_reset: bool, target_directory: str, num_worke
                         if not success:
                             error_log.write(f"{check_path}\n")
                     result_futures = []
+            for future in result_futures:
+                x = future.result()
+                print(f"Future result: {x}")
+                success, check_path = x
+                if not success:
+                    error_log.write(f"{check_path}\n")
+                result_futures = []
 
 
 def _create_error_file_name(target_dir: str, output_dir: str) -> str:

--- a/parallel_reset_commands/parallel_acl_controller.py
+++ b/parallel_reset_commands/parallel_acl_controller.py
@@ -41,7 +41,7 @@ def _piece_out_acl(acl_info: str) -> Set[str]:
         acl_set.add(line.strip())
     return acl_set
 
-def check_acl(original_path, processed_path, expected_spec):
+def check_acl(original_path, processed_path, expected_spec, path_type):
     if os.path.islink(original_path):
         # links don't have ACLs
         return True
@@ -60,6 +60,7 @@ def check_acl(original_path, processed_path, expected_spec):
             logging.error(f"ACL mismatch for {processed_path}")
             logging.error(f"Expected: {expected_set}")
             logging.error(f"Actual: {result_set}")
+            logging.error(f"Path Type: {path_type}")
             return False, acl_info
         return True, acl_info
     except subprocess.CalledProcessError as e:
@@ -74,7 +75,7 @@ def process_acl(perform_reset: bool, path: str, path_type: str, builder: ACL_Spe
         if perform_reset:
             reset_command = f'nfs4_setfacl -s "{spec}" {processed_path}'
             subprocess.run(reset_command, check=True, shell=True)
-        success, acl_info = check_acl(path, processed_path, spec)
+        success, acl_info = check_acl(path, processed_path, spec, path_type)
         return success, acl_info, path
     except subprocess.CalledProcessError as e:
         return False, None, path

--- a/parallel_reset_commands/parallel_acl_controller.py
+++ b/parallel_reset_commands/parallel_acl_controller.py
@@ -99,14 +99,14 @@ def process_acls_recursive(perform_reset: bool, target_directory: str, num_worke
                         success, acl_info, check_path = x
                         if not success:
                             error_log.write("---------\n")
-                            error_log.write(f"{check_path} {acl_info} {builder.get_spec_by_path(process_path(path)), path_type}\n")
+                            error_log.write(f"{check_path} {acl_info} {builder.get_spec_by_path(process_path(path), 'directory')}\n")
                     result_futures = []
             for future in result_futures:
                 x = future.result()
                 success, acl_info, check_path = x
                 if not success:
                     error_log.write("---------\n")
-                    error_log.write(f"{check_path} {acl_info} {builder.get_spec_by_path(process_path(path)), 'directory'}\n")
+                    error_log.write(f"{check_path} {acl_info} {builder.get_spec_by_path(process_path(path), 'directory')}\n")
                 result_futures = []
 
 

--- a/parallel_reset_commands/parallel_acl_controller.py
+++ b/parallel_reset_commands/parallel_acl_controller.py
@@ -117,6 +117,7 @@ def main():
 
     # find the depth at which there are >= num_walkers subdirectories to use as parallel targets
     result = find_depth_for_target_dirs(parser.get_target_dir(), parser.get_num_walkers())
+    print(result)
 
     if result is None:
         # if there are not enough subdirectories, just process the whole thing

--- a/parallel_reset_commands/parallel_acl_controller.py
+++ b/parallel_reset_commands/parallel_acl_controller.py
@@ -116,11 +116,13 @@ def main():
         os.makedirs(parser.get_log_dir())
 
     # find the depth at which there are >= num_walkers subdirectories to use as parallel targets
-    result = find_depth_for_target_dirs(parser.get_target_dir(), parser.get_num_walkers())
-    print(result)
+    if parser.get_num_walkers() > 1:
+        result = find_depth_for_target_dirs(parser.get_target_dir(), parser.get_num_walkers())
+    else:
+        result = None
 
     if result is None:
-        # if there are not enough subdirectories, just process the whole thing
+        # if there are not enough subdirectories or you only have one walker, just process the whole thing
         print("Not enough subdirectories found for parallel processing. Processing the entire directory.")
         process_acls_recursive(
             parser.get_perform_reset(),

--- a/parallel_reset_commands/parallel_acl_controller.py
+++ b/parallel_reset_commands/parallel_acl_controller.py
@@ -96,7 +96,9 @@ def process_acls_recursive(perform_reset: bool, target_directory: str, num_worke
                     print(f"Batch count: {batch_count}")
                     batch_count += 1
                     for future in result_futures:
-                        success, check_path = future.result()
+                        x = future.result()
+                        print(f"Future result: {x}")
+                        success, check_path = x
                         if not success:
                             error_log.write(f"{check_path}\n")
                     result_futures = []

--- a/parallel_reset_commands/parallel_acl_controller.py
+++ b/parallel_reset_commands/parallel_acl_controller.py
@@ -168,5 +168,17 @@ def main():
             lambda x: walk_to_max_depth(x, dir_depth)
         )
 
+    # after the processing is 100% done, we can consolidate the error logs
+    # into a single file
+    error_files = [f for f in os.listdir(parser.get_log_dir()) if f.endswith(".log")]
+    consolidated_error_file = os.path.join(parser.get_log_dir(), f"{os.path.basename(parser.get_target_dir().rstrip('/'))}_consolidated_errors.log")
+    
+    with open(consolidated_error_file, 'w') as consolidated_file:
+        for error_file in error_files:
+            error_file_path = os.path.join(parser.get_log_dir(), error_file)
+            with open(error_file_path, 'r') as ef:
+                consolidated_file.write(ef.read())
+            os.remove(error_file_path)
+
 if __name__ == "__main__":
     main()

--- a/parallel_reset_commands/parallel_acl_controller.py
+++ b/parallel_reset_commands/parallel_acl_controller.py
@@ -1,0 +1,163 @@
+import os
+import subprocess
+from concurrent.futures import ProcessPoolExecutor
+
+from directory_walker import walk_recursive_from_target, walk_to_max_depth, find_depth_for_target_dirs
+
+from acl_spec_builder import ACL_SpecBuilder
+
+from argument_parser import ArgumentParser
+
+from typing import List, Set, Callable
+
+from constants import BATCH_SIZE
+import datetime
+
+def process_path(result):
+    result = result.replace("\\", "\\\\")
+    result = result.replace("@", "\\@")
+    result = result.replace("=", "\\=")
+    result = result.replace(";", "\\;")
+    result = result.replace("~", "\\~")
+    result = result.replace("$", "\\$")
+    result = result.replace("(", "\\(")
+    result = result.replace(")", "\\)")
+    result = result.replace("'", "\\'")
+    result = result.replace(" ", "\\ ")
+    result = result.replace("&", "\\&")
+    result = result.replace(".", "\\.")
+    result = result.replace("`", "\\`")
+    return result
+
+def _piece_out_acl(acl_info: str) -> Set[str]:
+    acl_lines = acl_info.splitlines()
+    acl_set = set()
+    for line in acl_lines:
+        if "#" in line or line.strip() == "":
+            continue
+        acl_set.add(line)
+    return acl_set
+
+def check_acl(original_path, processed_path, expected_spec):
+    if os.path.islink(original_path):
+        # links don't have ACLs
+        return True
+    # NOTE: prefixing 'sudo' results in different behavior
+    # even though the whole script is run as `sudo` and that
+    # elevated status *should* be inherited by the spawned
+    # subprocesses
+    # getfacl_command = f"sudo nfs4_getfacl {processed_path}"
+    getfacl_command = f"nfs4_getfacl {processed_path}"
+    try:
+        result = subprocess.check_output(getfacl_command, shell=True)
+        acl_info = str(result, 'utf-8')
+        result_set = _piece_out_acl(acl_info)
+        expected_set = _piece_out_acl(expected_spec)
+        if result_set != expected_set:
+            return False
+        return True
+    except subprocess.CalledProcessError as e:
+        return False
+
+def process_acl(perform_reset: bool, path: str, path_type: str, builder: ACL_SpecBuilder) -> bool:
+    if os.path.islink(path):
+        return True, path
+    processed_path = process_path(path)
+    spec = builder.get_spec_by_path(path, path_type)
+    try:
+        if perform_reset:
+            reset_command = f'nfs4_setfacl -s "{spec}" {processed_path}'
+            subprocess.run(reset_command, check=True, shell=True)
+        return check_acl(path, processed_path, spec), path
+    except subprocess.CalledProcessError as e:
+        print(f'Failed to set ACL for {path_type}: {path}, Error: {e}')
+        return False, path
+
+
+
+def process_acls_recursive(perform_reset: bool, target_directory: str, num_workers: int, alloc_name: str, sub_alloc_names: List[str], error_file: str, walker_method: Callable):
+    print(f"Processing ACLs recursively in {target_directory} with {num_workers} workers.")
+    with ProcessPoolExecutor(max_workers=num_workers) as executor:
+        builder = ACL_SpecBuilder()
+        builder.build_specs(alloc_name, sub_alloc_names)
+        count = 0
+        batch_count = 0
+        result_futures = []
+        with open(error_file, 'w') as error_log:
+            for path, path_type in walker_method(target_directory):
+                if count % 1000 == 0:
+                    # print(f'Number pending tasks: {executor._work_queue.qsize()}')
+                    print(f'Processed {count} paths')
+                count += 1
+                ret = executor.submit(process_acl, perform_reset, path, path_type, builder)
+                result_futures.append(ret)
+                if len(result_futures) == BATCH_SIZE:
+                    print(f"Batch count: {batch_count}")
+                    batch_count += 1
+                    for future in result_futures:
+                        success, check_path = future.result()
+                        if not success:
+                            error_log.write(f"{check_path}\n")
+                    result_futures = []
+
+
+def _create_error_file_name(target_dir: str, output_dir: str) -> str:
+    timestamp = datetime.datetime.now().strftime("%Y_%m_%d_%H_%M_%S")
+    base_name = os.path.basename(target_dir.rstrip('/'))
+    return f"{output_dir}/{base_name}_errors_{timestamp}.log"
+
+
+def main():
+    # get the arguments from the user using ArgumentParser
+    parser = ArgumentParser()
+    parser.retrieve_args()
+    # go ahead and make a directory for the logs
+    if not os.path.exists(parser.get_log_dir()):
+        os.makedirs(parser.get_log_dir())
+
+    # find the depth at which there are >= num_walkers subdirectories to use as parallel targets
+    result = find_depth_for_target_dirs(parser.get_target_dir(), parser.get_num_walkers())
+
+    if result is None:
+        # if there are not enough subdirectories, just process the whole thing
+        print("Not enough subdirectories found for parallel processing. Processing the entire directory.")
+        process_acls_recursive(
+            parser.get_perform_reset(),
+            parser.get_target_dir(),
+            parser.get_num_workers_per_walk(),
+            parser.get_allocation_name(),
+            parser.get_sub_allocations(),
+            _create_error_file_name(parser.get_target_dir(), parser.get_log_dir()),
+            walk_recursive_from_target
+        )
+    else:
+        dir_depth, dir_count, dirs_at_depth = result
+        # if there are enough subdirectories, process them in parallel
+        print(f"Processing {len(dirs_at_depth)} subdirectories in parallel.")
+        with ProcessPoolExecutor(max_workers=parser.get_num_walkers()) as walk_executor:
+            for subdir in dirs_at_depth:
+                _ = walk_executor.submit(
+                    process_acls_recursive,
+                    parser.get_perform_reset(),
+                    subdir,
+                    parser.get_num_workers_per_walk(),
+                    parser.get_allocation_name(),
+                    parser.get_sub_allocations(),
+                    _create_error_file_name(subdir, parser.get_log_dir()),
+                    walk_recursive_from_target
+                )
+                # do I need to inspect the results of these parallel processors?
+                # or just rely on the log files they produce
+        # now, use walk_to_max_depth to pick up the remaining files/directories *above* that parallelization target level
+        process_acls_recursive(
+            parser.get_perform_reset(),
+            parser.get_target_dir(),
+            parser.get_num_workers_per_walk(),
+            parser.get_allocation_name(),
+            parser.get_sub_allocations(),
+            _create_error_file_name(parser.get_target_dir(), parser.get_log_dir()),
+            lambda x: walk_to_max_depth(x, dir_depth)
+        )
+
+if __name__ == "__main__":
+    main()

--- a/parallel_reset_commands/parallel_acl_controller.py
+++ b/parallel_reset_commands/parallel_acl_controller.py
@@ -54,6 +54,7 @@ def check_acl(original_path, processed_path, expected_spec):
         result_set = _piece_out_acl(acl_info)
         expected_set = _piece_out_acl(expected_spec)
         if result_set != expected_set:
+            print(f"Returning False {processed_path}")
             return False
         return True
     except subprocess.CalledProcessError as e:

--- a/parallel_reset_commands/parallel_acl_controller.py
+++ b/parallel_reset_commands/parallel_acl_controller.py
@@ -97,8 +97,7 @@ def process_acls_recursive(perform_reset: bool, target_directory: str, num_worke
                     # print(f"Batch count: {batch_count}")
                     batch_count += 1
                     for future in result_futures:
-                        x = future.result()
-                        success, check_path = x
+                        success, check_path = future.result()
                         if not success:
                             error_log.write(f"{check_path}\n")
                     result_futures = []

--- a/parallel_reset_commands/parallel_acl_controller.py
+++ b/parallel_reset_commands/parallel_acl_controller.py
@@ -13,6 +13,9 @@ from typing import List, Set, Callable
 from constants import BATCH_SIZE
 import datetime
 
+import logging
+# logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
+
 def process_path(result):
     result = result.replace("\\", "\\\\")
     result = result.replace("@", "\\@")
@@ -54,6 +57,9 @@ def check_acl(original_path, processed_path, expected_spec):
         result_set = _piece_out_acl(acl_info)
         expected_set = _piece_out_acl(expected_spec)
         if result_set != expected_set:
+            logging.error(f"ACL mismatch for {processed_path}")
+            logging.error(f"Expected: {expected_set}")
+            logging.error(f"Actual: {result_set}")
             return False, acl_info
         return True, acl_info
     except subprocess.CalledProcessError as e:

--- a/parallel_reset_commands/parallel_acl_controller.py
+++ b/parallel_reset_commands/parallel_acl_controller.py
@@ -189,6 +189,10 @@ def main():
             with open(error_file_path, 'r') as ef:
                 consolidated_file.write(ef.read())
             os.remove(error_file_path)
+    
+    # If the consolidated error file is empty, delete it
+    if os.path.exists(consolidated_error_file) and os.path.getsize(consolidated_error_file) == 0:
+        os.remove(consolidated_error_file)
 
 if __name__ == "__main__":
     main()

--- a/parallel_reset_commands/parallel_acl_controller.py
+++ b/parallel_reset_commands/parallel_acl_controller.py
@@ -105,6 +105,7 @@ def process_acls_recursive(perform_reset: bool, target_directory: str, num_worke
                 x = future.result()
                 success, acl_info, check_path = x
                 if not success:
+                    error_log.write("---------\n")
                     error_log.write(f"{check_path} {acl_info} {builder.get_spec_by_path(process_path(path)), 'directory'}\n")
                 result_futures = []
 

--- a/parallel_reset_commands/parallel_acl_controller.py
+++ b/parallel_reset_commands/parallel_acl_controller.py
@@ -30,6 +30,7 @@ def process_path(result):
     result = result.replace("&", "\\&")
     result = result.replace(".", "\\.")
     result = result.replace("`", "\\`")
+    result = result.replace("|", "\\|")
     return result
 
 def _piece_out_acl(acl_info: str) -> Set[str]:

--- a/parallel_reset_commands/parallel_acl_controller.py
+++ b/parallel_reset_commands/parallel_acl_controller.py
@@ -35,7 +35,7 @@ def _piece_out_acl(acl_info: str) -> Set[str]:
     for line in acl_lines:
         if "#" in line or line.strip() == "":
             continue
-        acl_set.add(line)
+        acl_set.add(line.strip())
     return acl_set
 
 def check_acl(original_path, processed_path, expected_spec):

--- a/parallel_reset_commands/parallel_acl_controller.py
+++ b/parallel_reset_commands/parallel_acl_controller.py
@@ -54,7 +54,7 @@ def check_acl(original_path, processed_path, expected_spec):
         result_set = _piece_out_acl(acl_info)
         expected_set = _piece_out_acl(expected_spec)
         if result_set != expected_set:
-            print(f"Returning False {processed_path}")
+            print(f"Returning False {processed_path} {expected_set} {result_set}")
             return False
         return True
     except subprocess.CalledProcessError as e:

--- a/parallel_reset_commands/parallel_acl_controller.py
+++ b/parallel_reset_commands/parallel_acl_controller.py
@@ -105,7 +105,7 @@ def process_acls_recursive(perform_reset: bool, target_directory: str, num_worke
                 x = future.result()
                 success, acl_info, check_path = x
                 if not success:
-                    error_log.write(f"{check_path} {acl_info} {builder.get_spec_by_path(process_path(path)), path_type}\n")
+                    error_log.write(f"{check_path} {acl_info} {builder.get_spec_by_path(process_path(path)), 'directory'}\n")
                 result_futures = []
 
 

--- a/parallel_reset_commands/parallel_walk_explanation.txt
+++ b/parallel_reset_commands/parallel_walk_explanation.txt
@@ -1,0 +1,61 @@
+/storage2/fs1/japrewitt
+/storage2/fs1/japrewitt/README
+/storage2/fs1/japrewitt/Active
+/storage2/fs1/japrewitt/Active/A
+/storage2/fs1/japrewitt/Active/A/A
+/storage2/fs1/japrewitt/Active/A/A/X
+/storage2/fs1/japrewitt/Active/A/B
+/storage2/fs1/japrewitt/Active/A/B/X
+/storage2/fs1/japrewitt/Active/B
+/storage2/fs1/japrewitt/Active/B/A
+/storage2/fs1/japrewitt/Active/B/A/X
+/storage2/fs1/japrewitt/Active/B/A/X/Y
+/storage2/fs1/japrewitt/Active/B/B
+/storage2/fs1/japrewitt/Active/B/B/X
+/storage2/fs1/japrewitt/Active/B/C
+/storage2/fs1/japrewitt/Active/C
+/storage2/fs1/japrewitt/Active/C/A
+/storage2/fs1/japrewitt/Active/C/A/X
+/storage2/fs1/japrewitt/Active/C/A/X/Y
+/storage2/fs1/japrewitt/Active/C/A/X/Y/Z
+
+0: 1 directory
+1: 3 directories
+2: 6 directories
+3: 5 directories
+4: 2 directories
+5: 1 directory
+
+if num_walkers is 2, parallelized walk will start at level 1 with:
+    /storage2/fs1/japrewitt/Active/A
+    /storage2/fs1/japrewitt/Active/B
+    /storage2/fs1/japrewitt/Active/C
+then a walk to depth 1 will happen, covering:
+    /storage2/fs1/japrewitt
+    /storage2/fs1/japrewitt/README
+    /storage2/fs1/japrewitt/Active
+    # NOTE: this repeat is deliberate as a precaution against fencepost errors 
+    # in future code updates
+    /storage2/fs1/japrewitt/Active/A
+    /storage2/fs1/japrewitt/Active/B
+    /storage2/fs1/japrewitt/Active/C
+
+if num_walkers is 4, parallelized walk will *NOT* start at level 1, but at level 2 with:
+    /storage2/fs1/japrewitt/Active/A/A
+    /storage2/fs1/japrewitt/Active/B/A
+    /storage2/fs1/japrewitt/Active/B/B
+    /storage2/fs1/japrewitt/Active/B/C
+    /storage2/fs1/japrewitt/Active/C/A
+then a walk to depth 2 will happen, covering:
+    /storage2/fs1/japrewitt
+    /storage2/fs1/japrewitt/README
+    /storage2/fs1/japrewitt/Active
+    /storage2/fs1/japrewitt/Active/A
+    /storage2/fs1/japrewitt/Active/A/A
+    /storage2/fs1/japrewitt/Active/A/B
+    /storage2/fs1/japrewitt/Active/B
+    /storage2/fs1/japrewitt/Active/B/A
+    /storage2/fs1/japrewitt/Active/B/B
+    /storage2/fs1/japrewitt/Active/B/C
+    /storage2/fs1/japrewitt/Active/C
+    /storage2/fs1/japrewitt/Active/C/A

--- a/parallel_reset_commands/templates/active_spec_sub_alloc_entry_template.txt
+++ b/parallel_reset_commands/templates/active_spec_sub_alloc_entry_template.txt
@@ -1,0 +1,2 @@
+A:g:storage-<ALLOC>-<SUB_ALLOC>-rw@accounts.ad.wustl.edu:rxtncy
+A:g:storage-<ALLOC>-<SUB_ALLOC>-ro@accounts.ad.wustl.edu:rxtncy

--- a/parallel_reset_commands/templates/active_spec_template.txt
+++ b/parallel_reset_commands/templates/active_spec_template.txt
@@ -1,0 +1,7 @@
+A::OWNER@:rwaDxtTnNcy
+A:dg:RIS-IT-ADMIN@accounts.ad.wustl.edu:rwaDxtTnNcy
+A:fig:RIS-IT-ADMIN@accounts.ad.wustl.edu:rwaDxtTnNcy
+A:dg:storage-<ALLOC>-rw@accounts.ad.wustl.edu:rwaDxtTnNcy
+A:fig:storage-<ALLOC>-rw@accounts.ad.wustl.edu:rwaDxtTnNcy
+A:dg:storage-<ALLOC>-ro@accounts.ad.wustl.edu:rxtncy
+A:fig:storage-<ALLOC>-ro@accounts.ad.wustl.edu:rtncy

--- a/parallel_reset_commands/templates/base_file_spec_template.txt
+++ b/parallel_reset_commands/templates/base_file_spec_template.txt
@@ -1,0 +1,4 @@
+A::OWNER@:rwaxtTnNcoy
+A:g:RIS-IT-ADMIN@accounts.ad.wustl.edu:rwaxtTnNcy
+A:g:storage-<ALLOC>-rw@accounts.ad.wustl.edu:rwaxtTnNcy
+A:g:storage-<ALLOC>-ro@accounts.ad.wustl.edu:rtncy

--- a/parallel_reset_commands/templates/base_folder_spec_template.txt
+++ b/parallel_reset_commands/templates/base_folder_spec_template.txt
@@ -1,0 +1,7 @@
+A::OWNER@:rwaDxtTnNcy
+A:dg:RIS-IT-ADMIN@accounts.ad.wustl.edu:rwaDxtTnNcy
+A:fig:RIS-IT-ADMIN@accounts.ad.wustl.edu:rwaDxtTnNcy
+A:dg:storage-<ALLOC>-rw@accounts.ad.wustl.edu:rwaDxtTnNcy
+A:fig:storage-<ALLOC>-rw@accounts.ad.wustl.edu:rwaDxtTnNcy
+A:dg:storage-<ALLOC>-ro@accounts.ad.wustl.edu:rxtncy
+A:fig:storage-<ALLOC>-ro@accounts.ad.wustl.edu:rtncy

--- a/parallel_reset_commands/templates/root_spec_sub_alloc_entry_template.txt
+++ b/parallel_reset_commands/templates/root_spec_sub_alloc_entry_template.txt
@@ -1,0 +1,2 @@
+A:g:storage-<ALLOC>-<SUB_ALLOC>-rw@accounts.ad.wustl.edu:rxtncy
+A:g:storage-<ALLOC>-<SUB_ALLOC>-ro@accounts.ad.wustl.edu:rxtncy

--- a/parallel_reset_commands/templates/root_spec_template.txt
+++ b/parallel_reset_commands/templates/root_spec_template.txt
@@ -1,0 +1,8 @@
+A:dg:storage-<ALLOC>-rw@accounts.ad.wustl.edu:rxtncy
+A:fg:storage-<ALLOC>-rw@accounts.ad.wustl.edu:rtncy
+A:dg:storage-<ALLOC>-ro@accounts.ad.wustl.edu:rxtncy
+A:fg:storage-<ALLOC>-ro@accounts.ad.wustl.edu:rtncy
+A:d:OWNER@:rwaDxtTnNcCoy
+A:f:OWNER@:rwaxtTnNcCoy
+A:dg:RIS-IT-ADMIN@accounts.ad.wustl.edu:rwaDxtTnNcy
+A:fg:RIS-IT-ADMIN@accounts.ad.wustl.edu:rwaDxtTnNcy

--- a/parallel_reset_commands/templates/sub_alloc_file_spec_template.txt
+++ b/parallel_reset_commands/templates/sub_alloc_file_spec_template.txt
@@ -1,0 +1,6 @@
+A::OWNER@:rwaxtTnNcCoy
+A:g:RIS-IT-ADMIN@accounts.ad.wustl.edu:rwaxtTnNcy
+A:g:storage-<ALLOC>-<SUB_ALLOC>-rw@accounts.ad.wustl.edu:rwaxtTnNcy
+A:g:storage-<ALLOC>-<SUB_ALLOC>-ro@accounts.ad.wustl.edu:rtncy
+A:g:storage-<ALLOC>-rw@accounts.ad.wustl.edu:rwaxtTnNcy
+A:g:storage-<ALLOC>-ro@accounts.ad.wustl.edu:rtncy

--- a/parallel_reset_commands/templates/sub_alloc_folder_spec_template.txt
+++ b/parallel_reset_commands/templates/sub_alloc_folder_spec_template.txt
@@ -1,0 +1,12 @@
+A:d:OWNER@:rwaDxtTnNcCoy
+A:fi:OWNER@:rwatTnNcCoy
+A:dg:RIS-IT-ADMIN@accounts.ad.wustl.edu:rwaDxtTnNcy
+A:fig:RIS-IT-ADMIN@accounts.ad.wustl.edu:rwaDtTnNcy
+A:dg:storage-<ALLOC>-rw@accounts.ad.wustl.edu:rwaDxtTnNcy
+A:fig:storage-<ALLOC>-rw@accounts.ad.wustl.edu:rwaDtTnNcy
+A:dg:storage-<ALLOC>-ro@accounts.ad.wustl.edu:rxtncy
+A:fig:storage-<ALLOC>-ro@accounts.ad.wustl.edu:rtncy
+A:dg:storage-<ALLOC>-<SUB_ALLOC>-rw@accounts.ad.wustl.edu:rwaDxtTnNcy
+A:fig:storage-<ALLOC>-<SUB_ALLOC>-rw@accounts.ad.wustl.edu:rwaDtTnNcy
+A:dg:storage-<ALLOC>-<SUB_ALLOC>-ro@accounts.ad.wustl.edu:rxtncy
+A:fig:storage-<ALLOC>-<SUB_ALLOC>-ro@accounts.ad.wustl.edu:rtncy

--- a/parallel_reset_commands/templates/sub_alloc_root_spec_template.txt
+++ b/parallel_reset_commands/templates/sub_alloc_root_spec_template.txt
@@ -1,0 +1,12 @@
+A:d:OWNER@:rwaDxtTnNcCoy
+A:f:OWNER@:rwaxtTnNcCoy
+A:dg:RIS-IT-ADMIN@accounts.ad.wustl.edu:rwaDxtTnNcy
+A:fg:RIS-IT-ADMIN@accounts.ad.wustl.edu:rwaDxtTnNcy
+A:dg:storage-<ALLOC>-<SUB_ALLOC>-rw@accounts.ad.wustl.edu:rwaDxtTnNcy
+A:fg:storage-<ALLOC>-<SUB_ALLOC>-rw@accounts.ad.wustl.edu:rwaDxtTnNcy
+A:dg:storage-<ALLOC>-<SUB_ALLOC>-ro@accounts.ad.wustl.edu:rxtncy
+A:fg:storage-<ALLOC>-<SUB_ALLOC>-ro@accounts.ad.wustl.edu:rtncy
+A:dg:storage-<ALLOC>-rw@accounts.ad.wustl.edu:rwaDxtTnNcy
+A:fg:storage-<ALLOC>-rw@accounts.ad.wustl.edu:rwaDxtTnNcy
+A:dg:storage-<ALLOC>-ro@accounts.ad.wustl.edu:rxtncy
+A:fg:storage-<ALLOC>-ro@accounts.ad.wustl.edu:rtncy


### PR DESCRIPTION
To run the script, simply call `python3 parallel_acl_controller.py`.  It will then prompt you for the following arguments:

1. Whether the script should perform a reset or just perform a check of existing ACLs
2. The root directory of the allocation (*NOT* ACTIVE, but the root - like `/storage2/fs1/prewitt_test`)
3. The target directory - the reset will run from here and below in the directory tree.  This can be the same as the root directory of the allocation, but does not have to be
4. Sub-allocation names - these are used by the ACL_SpecBuilder to create the proper ACLs for sub-allocations and traverse ACLs for the root and Active directories; enter them as a comma-delimited list
5. Number of walkers and workers - the number of walkers controls the number of processes iterating through the contents of the allocation underneath the target directory while the number of workers controls the size of the worker pool for *each* walker process.  So 2 walkers and 10 workers will spawn 2 walker processes and 20 worker processes in total.
6. A log directory for errors