### PR TITLE
User Support Ask: Consumption and 5tb are defaults on create allocation page ITDEV-36620

### DIFF
--- a/coldfront/plugins/qumulo/forms/AllocationForm.py
+++ b/coldfront/plugins/qumulo/forms/AllocationForm.py
@@ -87,6 +87,7 @@ class AllocationForm(forms.Form):
         help_text="Service rate option for the Storage2 allocation",
         label="Service Rate",
         choices=STORAGE_SERVICE_RATES,
+        initial="consumption",
     )
     storage_quota = forms.IntegerField(
         min_value=0,

--- a/coldfront/plugins/qumulo/services/allocation_service.py
+++ b/coldfront/plugins/qumulo/services/allocation_service.py
@@ -256,7 +256,7 @@ class AllocationService:
         allocation_defaults = {
             "secure": "No",
             "audit": "No",
-            "subsidized": "No",
+            "subsidized": "Yes",
         }
 
         for attr, value in allocation_defaults.items():

--- a/coldfront/plugins/qumulo/static/migration_mappings/itsm_to_coldfront_map.yaml
+++ b/coldfront/plugins/qumulo/static/migration_mappings/itsm_to_coldfront_map.yaml
@@ -402,7 +402,7 @@ itsm_to_coldfront_map:
       attribute: subsidized
       type: boolean
       nulls: true
-      defaults_to: false
+      defaults_to: true
   quota:
     coldfront:
       - entity: allocation_form

--- a/coldfront/plugins/qumulo/static/migration_mappings/itsm_to_coldfront_map.yaml
+++ b/coldfront/plugins/qumulo/static/migration_mappings/itsm_to_coldfront_map.yaml
@@ -336,7 +336,7 @@ itsm_to_coldfront_map:
       type: string
       values: ["condo", "consumption", "subscription"] # if the status is active
       nulls: true
-      defaults_to: subscription
+      defaults_to: consumption
   comment:
     coldfront:
       - entity: allocation_attribute

--- a/coldfront/plugins/qumulo/tests/views/test_allocation_view.py
+++ b/coldfront/plugins/qumulo/tests/views/test_allocation_view.py
@@ -62,7 +62,7 @@ class AllocationViewTests(TestCase):
             "secure": "No",
             "audit": "No",
             "billing_exempt": "No",
-            "subsidized": "No",
+            "subsidized": "Yes",
         }
         for attr, value in allocation_defaults.items():
             attribute_type = AllocationAttributeType.objects.get(name=attr)

--- a/coldfront/plugins/qumulo/tests_integration/views/test_trigger_migrations_view.py
+++ b/coldfront/plugins/qumulo/tests_integration/views/test_trigger_migrations_view.py
@@ -9,7 +9,7 @@ from unittest.mock import MagicMock
 
 
 class TriggerMigrationsViewTests(TestCase):
-    def setUp(self) -> None:
+    def set_up(self) -> None:
         create_allocation_assets()
 
     @tag("integration")

--- a/coldfront/plugins/qumulo/tests_integration/views/test_trigger_migrations_view.py
+++ b/coldfront/plugins/qumulo/tests_integration/views/test_trigger_migrations_view.py
@@ -9,7 +9,7 @@ from unittest.mock import MagicMock
 
 
 class TriggerMigrationsViewTests(TestCase):
-    def set_up(self) -> None:
+    def setUp(self) -> None:
         create_allocation_assets()
 
     @tag("integration")


### PR DESCRIPTION
Testing Instructions:
1. Navigate to the Create Allocation page and verify that the initial value for Service Rate Category is consumption.
2. Create an allocation and then navigate to the allocation detail page, verify that Subsidized is yes. 