### PR TITLE
Bugfix/itdev 36629 prepaid expiration calculation

### DIFF
--- a/coldfront/plugins/qumulo/management/commands/check_billing_cycles.py
+++ b/coldfront/plugins/qumulo/management/commands/check_billing_cycles.py
@@ -11,6 +11,7 @@ from coldfront.core.resource.models import Resource
 from django.db.models import OuterRef, Subquery
 
 from datetime import datetime
+from dateutil.relativedelta import relativedelta
 
 
 logger = logging.getLogger(__name__)
@@ -64,12 +65,7 @@ def calculate_prepaid_expiration(
     if bill_cycle == "prepaid" and prepaid_expiration == None:
         prepaid_billing_start = datetime.strptime(prepaid_billing_start, "%Y-%m-%d")
         prepaid_months = int(prepaid_months)
-        prepaid_until = datetime(
-            prepaid_billing_start.year
-            + (prepaid_billing_start.month + prepaid_months - 1) // 12,
-            (prepaid_billing_start.month + prepaid_months - 1) % 12 + 1,
-            prepaid_billing_start.day,
-        )
+        prepaid_until = prepaid_billing_start + relativedelta(months=prepaid_months)
         AllocationAttribute.objects.create(
             allocation=allocation,
             allocation_attribute_type=prepaid_expiration_attribute,

--- a/coldfront/plugins/qumulo/management/commands/check_billing_cycles.py
+++ b/coldfront/plugins/qumulo/management/commands/check_billing_cycles.py
@@ -1,4 +1,4 @@
-import logging
+from django.db.models import OuterRef, Subquery
 
 from coldfront.config.env import ENV
 from coldfront.core.allocation.models import (
@@ -8,10 +8,10 @@ from coldfront.core.allocation.models import (
 )
 from coldfront.core.resource.models import Resource
 
-from django.db.models import OuterRef, Subquery
-
 from datetime import datetime
 from dateutil.relativedelta import relativedelta
+import calendar
+import logging
 
 
 logger = logging.getLogger(__name__)
@@ -62,10 +62,16 @@ def calculate_prepaid_expiration(
         name="prepaid_expiration"
     )
     logger.warn(f"Calculation prepaid expiration")
+    
     if bill_cycle == "prepaid" and prepaid_expiration == None:
         prepaid_billing_start = datetime.strptime(prepaid_billing_start, "%Y-%m-%d")
         prepaid_months = int(prepaid_months)
         prepaid_until = prepaid_billing_start + relativedelta(months=prepaid_months)
+
+        if prepaid_billing_start.day == calendar.monthrange(prepaid_until.year, prepaid_until.month)[1]:
+            new_day = calendar.monthrange(prepaid_until.year, prepaid_until.month)[1]
+            prepaid_until.replace(day=new_day)
+
         AllocationAttribute.objects.create(
             allocation=allocation,
             allocation_attribute_type=prepaid_expiration_attribute,


### PR DESCRIPTION
Previously an allocation with a prepaid billing start date like "03/31/2025" would result in a calculated prepaid expiration date that does not exist (like "04/31/2025"). Currently users are only allowed to have prepaid start dates on the first of the month. This issue is not currently impacting users, but it has caused unit tests to occasionally fail. These revisions will prevent future failures.

To manually test create a prepaid allocation with any prepaid start date as long as it is on the first of the month and is in the past (like 04/01/2025). Once the allocation is active, run `coldfront run_check_billing_cycles` in the coldfront-dev-1 container (if testing locally) to verify the prepaid expiration date is calculated as expected.