### PR TITLE
Feature/itdev 36833 generate billing result set for coldfront

### DIFF
--- a/coldfront/plugins/qumulo/tests/utils/test_billing_result_set.py
+++ b/coldfront/plugins/qumulo/tests/utils/test_billing_result_set.py
@@ -1,0 +1,44 @@
+from django.test import TestCase, Client
+
+from coldfront.plugins.qumulo.utils.billing_result_set import BillingResultSet
+from coldfront.plugins.qumulo.tests.utils.mock_data import (
+    build_models,
+    create_allocation,
+)
+
+class TestBillingResultSet(TestCase):
+    def setUp(self):
+        self.client = Client()
+        build_data = build_models()
+
+        self.project = build_data["project"]
+        self.user = build_data["user"]
+
+        self.default_form_data = {
+            "storage_filesystem_path": "foo",
+            "storage_export_path": "bar",
+            "storage_ticket": "ITSD-54321",
+            "storage_name": "baz",
+            "storage_quota": 7,
+            "protocols": ["nfs"],
+            "rw_users": ["test"],
+            "ro_users": ["test1"],
+            "cost_center": "Uncle Pennybags",
+            "billing_exempt": "No",
+            "department_number": "Time Travel Services",
+            "billing_cycle": "monthly",
+            "service_rate": "general",
+        }
+
+        create_allocation(
+            project=self.project,
+            user=self.user,
+            form_data=self.default_form_data
+        )
+
+        return super().setUp()
+
+
+
+    def test_monthly(self):
+        BillingResultSet.retrieve_billing_result_set("monthly", "03/01/2025", "07/01/2025")

--- a/coldfront/plugins/qumulo/tests/utils/test_billing_result_set.py
+++ b/coldfront/plugins/qumulo/tests/utils/test_billing_result_set.py
@@ -5,6 +5,9 @@ from coldfront.plugins.qumulo.tests.utils.mock_data import (
     build_models,
     create_allocation,
 )
+from coldfront.core.allocation.models import (
+    AttributeType, AllocationAttributeType, AllocationStatusChoice
+)
 
 class TestBillingResultSet(TestCase):
     def setUp(self):
@@ -30,15 +33,20 @@ class TestBillingResultSet(TestCase):
             "service_rate": "general",
         }
 
-        create_allocation(
+        new_alloc = create_allocation(
             project=self.project,
             user=self.user,
             form_data=self.default_form_data
         )
+
+        new_alloc.status = AllocationStatusChoice.objects.get(name="Active")
+        new_alloc.end_date = "2025-06-30"
+        new_alloc.start_date = "2025-03-01"
+        new_alloc.save()
 
         return super().setUp()
 
 
 
     def test_monthly(self):
-        BillingResultSet.retrieve_billing_result_set("monthly", "03/01/2025", "07/01/2025")
+        BillingResultSet.retrieve_billing_result_set("monthly", "2025-05-01 00:00:00", "2025-05-31 00:00:00")

--- a/coldfront/plugins/qumulo/tests/utils/test_billing_result_set.py
+++ b/coldfront/plugins/qumulo/tests/utils/test_billing_result_set.py
@@ -44,9 +44,25 @@ class TestBillingResultSet(TestCase):
         new_alloc.start_date = "2025-03-01"
         new_alloc.save()
 
+        out_of_date_alloc = create_allocation(
+            project=self.project,
+            user=self.user,
+            form_data=self.default_form_data
+        )
+
+        out_of_date_alloc.status = AllocationStatusChoice.objects.get(name="Active")
+        out_of_date_alloc.end_date = "2024-06-30"
+        out_of_date_alloc.start_date = "2024-03-01"
+        out_of_date_alloc.save()
+
         return super().setUp()
 
 
 
     def test_monthly(self):
-        BillingResultSet.retrieve_billing_result_set("monthly", "2025-05-01 00:00:00", "2025-05-31 00:00:00")
+        listl = BillingResultSet.retrieve_billing_result_set("monthly", "2025-04-30 00:00:00", "2025-06-01 00:00:00")
+        count = len([l for l in listl if isinstance(l, dict)])
+        expected_dict = {'billing_cycle': 'monthly', 'cost_center': 'Uncle Pennybags', 'subsidized': None, 'billing_exempt': 'No', 'pi': 'test', 'usage': 0.0}
+        
+        self.assertDictEqual(listl[0], expected_dict)
+        self.assertEqual(count, 1)

--- a/coldfront/plugins/qumulo/utils/billing_result_set.py
+++ b/coldfront/plugins/qumulo/utils/billing_result_set.py
@@ -1,0 +1,36 @@
+from django.db.models import Q
+from django.db.models import OuterRef, Subquery
+
+from coldfront.core.allocation.models import Allocation, AllocationAttribute
+from coldfront.core.resource.models import Resource
+from coldfront.core.project.models import Project
+
+class BillingResultSet():
+    def retrieve_billing_result_set(billing_cycle, begin_billing, end_billing):
+        resource = Resource.objects.get(name="Storage2")
+        allocation_list = Allocation.objects.filter(resources=resource)
+        project = Project.objects.all()
+
+        billing_cycle_sub_query = AllocationAttribute.objects.filter(
+        allocation=OuterRef("pk"), allocation_attribute_type__name="billing_cycle",
+        ).values("value")[:1]
+        cost_center_sub_query = AllocationAttribute.objects.filter(
+        allocation=OuterRef("pk"), allocation_attribute_type__name="cost_center"
+        ).values("value")[:1]
+        subsidized_sub_query = AllocationAttribute.objects.filter(
+        allocation=OuterRef("pk"), allocation_attribute_type__name="subsidized"
+        ).values("value")[:1]
+        billing_exempt_sub_query = AllocationAttribute.objects.filter(
+        allocation=OuterRef("pk"), allocation_attribute_type__name="billing_exempt"
+        ).values("value")[:1]
+        pi_subquery = Project.objects.filter(allocation=OuterRef("pk")).values('pi')[:1]
+        
+        
+        allocation_list = allocation_list.annotate(billing_cycle=Subquery(billing_cycle_sub_query), 
+                                                   cost_center=Subquery(cost_center_sub_query), 
+                                                   subsidized=Subquery(subsidized_sub_query),
+                                                   billing_exempt=Subquery(billing_exempt_sub_query),
+                                                   pi=Subquery(pi_subquery),)
+        breakpoint()
+
+        return allocation_list

--- a/coldfront/plugins/qumulo/utils/billing_result_set.py
+++ b/coldfront/plugins/qumulo/utils/billing_result_set.py
@@ -1,15 +1,20 @@
 from django.db.models import Q
 from django.db.models import OuterRef, Subquery
+from django.utils.timezone import make_aware
 
-from coldfront.core.allocation.models import Allocation, AllocationAttribute, AllocationAttributeType, AllocationUser
+from coldfront.core.allocation.models import Allocation, AllocationAttribute, AllocationAttributeType, AllocationUser, AllocationAttributeUsage
 from coldfront.core.resource.models import Resource
 from coldfront.core.project.models import Project
 
+from datetime import datetime
+
 class BillingResultSet():
     def retrieve_billing_result_set(billing_cycle, begin_billing, end_billing):
-        resource = Resource.objects.get(name="Storage2")
-        allocation_list = Allocation.objects.filter(Q(resources=resource) & Q(start_date__gte=begin_billing) & Q(end_date__lte=end_billing))
-        project_ids = Allocation.objects.filter(resources=resource).values_list('project', flat=True)
+        date_format = "%Y-%m-%d %H:%M:%S"
+        begin_billing_datetime = datetime.strptime(begin_billing, date_format)
+        end_billing_datetime = datetime.strptime(end_billing, date_format)
+        allocation_list = Allocation.objects.filter(Q(resources__name="Storage2") & Q(start_date__lte=begin_billing_datetime) | Q(end_date__gte=end_billing_datetime))
+        project_ids = Allocation.objects.filter(resources__name="Storage2").values_list('project', flat=True)
         
         billing_cycle_sub_query = AllocationAttribute.objects.filter(
         allocation=OuterRef("pk"), allocation_attribute_type__name="billing_cycle",
@@ -23,21 +28,18 @@ class BillingResultSet():
         billing_exempt_sub_query = AllocationAttribute.objects.filter(
         allocation=OuterRef("pk"), allocation_attribute_type__name="billing_exempt"
         ).values("value")[:1]
-        project_attribute_pi = Project.objects.filter(id__in=project_ids).values("pi_id")
-        usage_sub_query = AllocationAttribute.objects.filter(
-        allocation=OuterRef("pk"), 
-        allocation_attribute_type__name="has_usage"
-        ).values("value")[:1]
-
-        
-        breakpoint()
+        project_attribute_pi = allocation_list.values('project')
+        usages = AllocationAttributeUsage.history.filter(allocation_attribute__allocation__in=allocation_list, 
+                                                         allocation_attribute__allocation_attribute_type__name="storage_quota", 
+                                                         allocation_attribute__allocation__status__name="Active", 
+                                                         history_date__range=(make_aware(begin_billing_datetime), make_aware(end_billing_datetime))).values("value")[:1]
+        #breakpoint()
         
         allocation_list = allocation_list.annotate(billing_cycle=Subquery(billing_cycle_sub_query), 
                                                    cost_center=Subquery(cost_center_sub_query), 
                                                    subsidized=Subquery(subsidized_sub_query),
                                                    billing_exempt=Subquery(billing_exempt_sub_query),
-                                                   pi=project_attribute_pi,
-                                                   usage=usage_sub_query)
-        breakpoint()
+                                                   #pi=project_attribute_pi.values("project__pi"),
+                                                   usage=usages).values('billing_cycle','cost_center','subsidized','billing_exempt','usage')
 
         return allocation_list

--- a/coldfront/plugins/qumulo/utils/billing_result_set.py
+++ b/coldfront/plugins/qumulo/utils/billing_result_set.py
@@ -1,7 +1,7 @@
 from django.db.models import Q
 from django.db.models import OuterRef, Subquery
 
-from coldfront.core.allocation.models import Allocation, AllocationAttribute
+from coldfront.core.allocation.models import Allocation, AllocationAttribute, AllocationAttributeType, AllocationUser
 from coldfront.core.resource.models import Resource
 from coldfront.core.project.models import Project
 
@@ -9,8 +9,8 @@ class BillingResultSet():
     def retrieve_billing_result_set(billing_cycle, begin_billing, end_billing):
         resource = Resource.objects.get(name="Storage2")
         allocation_list = Allocation.objects.filter(resources=resource)
-        project = Project.objects.all()
-
+        project_ids = Allocation.objects.filter(resources=resource).values_list('project', flat=True)
+        
         billing_cycle_sub_query = AllocationAttribute.objects.filter(
         allocation=OuterRef("pk"), allocation_attribute_type__name="billing_cycle",
         ).values("value")[:1]
@@ -23,14 +23,15 @@ class BillingResultSet():
         billing_exempt_sub_query = AllocationAttribute.objects.filter(
         allocation=OuterRef("pk"), allocation_attribute_type__name="billing_exempt"
         ).values("value")[:1]
-        pi_subquery = Project.objects.filter(allocation=OuterRef("pk")).values('pi')[:1]
+        project_attribute_pi = Project.objects.filter(id__in=project_ids).values("pi_id")
         
+        breakpoint()
         
         allocation_list = allocation_list.annotate(billing_cycle=Subquery(billing_cycle_sub_query), 
                                                    cost_center=Subquery(cost_center_sub_query), 
                                                    subsidized=Subquery(subsidized_sub_query),
                                                    billing_exempt=Subquery(billing_exempt_sub_query),
-                                                   pi=Subquery(pi_subquery),)
+                                                   pi=project_attribute_pi,)
         breakpoint()
 
         return allocation_list

--- a/coldfront/plugins/qumulo/utils/billing_result_set.py
+++ b/coldfront/plugins/qumulo/utils/billing_result_set.py
@@ -11,7 +11,7 @@ class BillingResultSet():
         date_format = "%Y-%m-%d %H:%M:%S"
         begin_billing_datetime = datetime.strptime(begin_billing, date_format)
         end_billing_datetime = datetime.strptime(end_billing, date_format)
-        allocation_list = Allocation.objects.filter(Q(resources__name="Storage2") & Q(start_date__lte=begin_billing_datetime) | Q(end_date__gte=end_billing_datetime))
+        allocation_list = Allocation.objects.filter(Q(resources__name="Storage2") & Q(start_date__gte=begin_billing_datetime) | Q(end_date__lte=end_billing_datetime))
         
         billing_cycle_sub_query = AllocationAttribute.objects.filter(
         allocation=OuterRef("pk"), allocation_attribute_type__name="billing_cycle",

--- a/coldfront/plugins/qumulo/utils/billing_result_set.py
+++ b/coldfront/plugins/qumulo/utils/billing_result_set.py
@@ -1,9 +1,7 @@
-from django.db.models import Q
-from django.db.models import OuterRef, Subquery
+from django.db.models import Q, OuterRef, Subquery
 from django.utils.timezone import make_aware
 
-from coldfront.core.allocation.models import Allocation, AllocationAttribute, AllocationAttributeType, AllocationUser, AllocationAttributeUsage
-from coldfront.core.resource.models import Resource
+from coldfront.core.allocation.models import Allocation, AllocationAttribute, AllocationAttributeUsage
 from coldfront.core.project.models import Project
 
 from datetime import datetime
@@ -14,7 +12,6 @@ class BillingResultSet():
         begin_billing_datetime = datetime.strptime(begin_billing, date_format)
         end_billing_datetime = datetime.strptime(end_billing, date_format)
         allocation_list = Allocation.objects.filter(Q(resources__name="Storage2") & Q(start_date__lte=begin_billing_datetime) | Q(end_date__gte=end_billing_datetime))
-        project_ids = Allocation.objects.filter(resources__name="Storage2").values_list('project', flat=True)
         
         billing_cycle_sub_query = AllocationAttribute.objects.filter(
         allocation=OuterRef("pk"), allocation_attribute_type__name="billing_cycle",
@@ -28,18 +25,17 @@ class BillingResultSet():
         billing_exempt_sub_query = AllocationAttribute.objects.filter(
         allocation=OuterRef("pk"), allocation_attribute_type__name="billing_exempt"
         ).values("value")[:1]
-        project_attribute_pi = allocation_list.values('project')
-        usages = AllocationAttributeUsage.history.filter(allocation_attribute__allocation__in=allocation_list, 
+        pi_sub_query = Project.objects.filter(allocation__in=allocation_list).values('pi__username')[:1]
+        usages_sub_query = AllocationAttributeUsage.history.filter(allocation_attribute__allocation__in=allocation_list, 
                                                          allocation_attribute__allocation_attribute_type__name="storage_quota", 
                                                          allocation_attribute__allocation__status__name="Active", 
                                                          history_date__range=(make_aware(begin_billing_datetime), make_aware(end_billing_datetime))).values("value")[:1]
-        #breakpoint()
         
         allocation_list = allocation_list.annotate(billing_cycle=Subquery(billing_cycle_sub_query), 
                                                    cost_center=Subquery(cost_center_sub_query), 
                                                    subsidized=Subquery(subsidized_sub_query),
                                                    billing_exempt=Subquery(billing_exempt_sub_query),
-                                                   #pi=project_attribute_pi.values("project__pi"),
-                                                   usage=usages).values('billing_cycle','cost_center','subsidized','billing_exempt','usage')
-
-        return allocation_list
+                                                   pi=Subquery(pi_sub_query),
+                                                   usage=usages_sub_query).values('billing_cycle','cost_center','subsidized','billing_exempt','usage', 'pi')
+        
+        return list(allocation_list)


### PR DESCRIPTION
This is my ticket that was assigned during our May on-site. This returns a list of dictionaries that contains the billing_cycle, cost_center, subsidized, billing_exempt, pi, and usage attributes of a Storage2 allocation in a set date range. 