### PR TITLE
Feature/itdev 36922 project page UI improvements

### DIFF
--- a/coldfront/core/project/forms.py
+++ b/coldfront/core/project/forms.py
@@ -47,7 +47,7 @@ class ProjectSearchForm(forms.Form):
     username = forms.CharField(label=USERNAME, max_length=100, required=False)
     field_of_science = forms.CharField(
         label=FIELD_OF_SCIENCE, max_length=100, required=False)
-    show_all_projects = forms.BooleanField(initial=False, required=False)
+    show_all_projects = forms.BooleanField(initial=True, required=False)
 
 
 class ProjectAddUserForm(forms.Form):

--- a/coldfront/core/project/templates/project/project_detail.html
+++ b/coldfront/core/project/templates/project/project_detail.html
@@ -175,6 +175,7 @@ Project Detail
               <th scope="col">Information</th>
               <th scope="col">Status</th>
               <th scope="col">End Date</th>
+              <th scope="col">Filesystem Path</th>
               <th scope="col" class="nosort">Actions</th>
             </tr>
           </thead>
@@ -196,6 +197,7 @@ Project Detail
                 <td class="text-info">{{ allocation.status.name }}</td>
               {% endif %}
               <td>{{allocation.end_date|date:"Y-m-d"}}</td>
+              <td>{{ allocation.filesystem_path }}</td>
               <td>
                 <a href="{% url 'allocation-detail' allocation.pk %}"><i class="far fa-folder-open" aria-hidden="true"></i><span class="sr-only">Details</span></a>
                 {% if allocation.is_locked and allocation.status.name == 'Active' and allocation.expires_in <= 60 and allocation.expires_in >= 0 %}

--- a/coldfront/core/project/views.py
+++ b/coldfront/core/project/views.py
@@ -18,11 +18,9 @@ from django.db.models import Q, OuterRef, Subquery
 from django.forms import formset_factory, modelformset_factory
 from django.http import (HttpResponse, HttpResponseForbidden,
                          HttpResponseRedirect)
-from django.shortcuts import redirect, render
 from django.urls import reverse
 from django.shortcuts import get_object_or_404, redirect, render
 from django.template.loader import render_to_string
-from django.urls import reverse
 from coldfront.core.allocation.utils import generate_guauge_data_from_usage
 from django.views import View
 from django.views.generic import CreateView, DetailView, ListView, UpdateView
@@ -192,13 +190,6 @@ class ProjectDetailView(LoginRequiredMixin, UserPassesTestMixin, DetailView):
             pass
 
         return context
-    
-    # def my_view(request):
-    #    if 'my_param' not in request.GET:
-    #        return redirect(reverse('my_view_name') + '?my_param=default')
-    #    my_param = request.GET.get('my_param')
-    #    # ... rest of your view logic ...
-    #    return render(request, 'my_template.html', {'my_param': my_param})
 
 
 class ProjectListView(LoginRequiredMixin, ListView):


### PR DESCRIPTION
Covers these asks from research facilitation:

- list path for each allocation in project page - currently does not usably differentiate between listings and admin needs to click into each folder to find the allocation they are targeting. 

- UI: remove “ro” and “rw” allocation listings in project page - User Support doesn’t need/want to see these and can make the list unnecessarily long when there are numerous sub allocations. 

- on Projects page filter, select “show all projects” by default