### PR TITLE
ITDEV-38208; clarified the report using report month for the monthly storage usage

### DIFF
--- a/coldfront/plugins/integratedbilling/storage_usage_report.py
+++ b/coldfront/plugins/integratedbilling/storage_usage_report.py
@@ -1,7 +1,7 @@
 import os
 import tempfile
 from typing import Any, Optional
-from datetime import date, datetime
+from datetime import date, datetime, timedelta
 from coldfront.plugins.integratedbilling.constants import ServiceTiers, QUERY_ATTRIBUTE
 from coldfront.plugins.qumulo.services.itsm.itsm_client_handler import ItsmClientHandler
 from coldfront.plugins.qumulo.reports.storage_usage_report import (
@@ -10,7 +10,7 @@ from coldfront.plugins.qumulo.reports.storage_usage_report import (
 
 CSV_USAGE_REPORT_HEADER_MAPPING = {
     "fiscal_year": "Fiscal Year",
-    "usage_month": "Date",
+    "report_month": "Date",
     "service": "Service",
     "unit": "School",
     "name": "Department",
@@ -266,13 +266,13 @@ class StorageUsageReport:
             else self.usage_date.year + 1
         )
         fiscal_year = f"FY{str(fiscal_year)[-2:]}"
-        usage_month = self.usage_date.strftime("%Y-%m")
+        report_month = (self.usage_date.replace(day=1) - timedelta(days=1)).strftime("%Y-%m")
         service = f"Storage {self.tier.name}"
         for entry in usage_data:
             formatted_entry = ",".join(
                 [
                     fiscal_year,
-                    usage_month,
+                    report_month,
                     service,
                     entry.get(self.report_attribute["unit"], "Unknown"),
                     entry.get(self.report_attribute["name"], "Unknown"),


### PR DESCRIPTION
The branch has been deployed to QA for testing:
```
$ kubectl exec -it deployment.apps/coldfront-deployment -n coldfront -- coldfront shell
Python 3.9.23 (main, Jul 22 2025, 01:41:20) 
[GCC 10.2.1 20210110] on linux
Type "help", "copyright", "credits" or "license" for more information.
(InteractiveConsole)
>>> from coldfront.plugins.integratedbilling.storage_usage_report import StorageUsageReport
>>> from datetime import date, datetime
>>> from coldfront.plugins.integratedbilling.constants import ServiceTiers
>>> storage_usage_report = StorageUsageReport(date(2026,4,1), ServiceTiers.Archive)
>>> report = storage_usage_report.generate_report('/tmp/storage_archive_usage_20260401.csv')
Storage usage report written to /tmp/storage_archive_usage_20260401.csv
>>> print(report)
```

Here is the expected output where you can see the report date `2026-03` for the storage usage on `2026-04-01`.
```
Fiscal Year,Date,Service,School,Department,Sponsor,Tier,Unit,Usage
FY26,2026-03,Storage Archive,ARTSCI,A&S - Anthropology,crickette.sanz,consumption,KB,3540376606
FY26,2026-03,Storage Archive,ARTSCI,A&S - Biology,kautt,consumption,KB,1437420262
FY26,2026-03,Storage Archive,ARTSCI,A&S - Biology,khengen,condo,KB,23373537540
FY26,2026-03,Storage Archive,ARTSCI,A&S - Biology,mallott,consumption,KB,1088177953
[skipped...]
```