### PR TITLE
Psv export command

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,20 +1,19 @@
 {
-    "[python]": {
-        "editor.defaultFormatter": "ms-python.black-formatter",
-        "editor.formatOnSave": true
-        
-    },
-    "[javascript]": {
-        "editor.defaultFormatter": "esbenp.prettier-vscode",
-        "editor.formatOnSave": true
-    },
-    "[javascriptreact]": {
-        "editor.defaultFormatter": "esbenp.prettier-vscode",
-        "editor.formatOnSave": true
-    },
-    "black-formatter.cwd": "${workspaceFolder}",
-    // "black-formatter.args": [
-    //     "['--exclude','coldfront/.*']",
-    //     "['--include','coldfront/.*/plugins/qumulo/.*']"
-    // ]
+  "[python]": {
+    "editor.defaultFormatter": "ms-python.black-formatter",
+    "editor.formatOnSave": true
+  },
+  "[javascript]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode",
+    "editor.formatOnSave": true
+  },
+  "[javascriptreact]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode",
+    "editor.formatOnSave": true
+  },
+  "black-formatter.cwd": "${workspaceFolder}"
+  // "black-formatter.args": [
+  //     "['--exclude','coldfront/.*']",
+  //     "['--include','coldfront/.*/plugins/qumulo/.*']"
+  // ]
 }

--- a/coldfront/plugins/qumulo/management/commands/export_suballocation_psv.py
+++ b/coldfront/plugins/qumulo/management/commands/export_suballocation_psv.py
@@ -2,11 +2,8 @@ from django.core.management.base import BaseCommand
 
 from coldfront.core.allocation.models import (
     Allocation,
-    AllocationStatusChoice,
-    AllocationLinkage,
+    AllocationLinkage,AllocationAttributeType
 )
-from coldfront.core.allocation.signals import allocation_activate
-
 
 class Command(BaseCommand):
     help = "Assemble a psv of specified allocations and suballocations.  Intended to be used with the ACL parrallel reset script"
@@ -24,7 +21,27 @@ class Command(BaseCommand):
         output_lines=[]
         allocation_paths = options["allocations"]
         
+        storage_filesystem_path_attribute_type = AllocationAttributeType.objects.get(
+            name="storage_filesystem_path"
+        )
+        
         for allocation_path in allocation_paths:
-          output_lines = allocation_path + "|{}"
+          suballocations = []
+          allocation = Allocation.objects.get(allocationattribute__allocation_attribute_type=storage_filesystem_path_attribute_type, allocationattribute__value=allocation_path)
+          
+          path_prefix = f"{allocation.get_attribute('storage_filesystem_path')}/Active/"
+          
+          try:
+            allocation_linkage_children = AllocationLinkage.objects.get(parent=allocation).children.all()
+          except AllocationLinkage.DoesNotExist:
+            allocation_linkage_children = []
+
+          for child_allocation in allocation_linkage_children:
+            filesystem_path: str = child_allocation.get_attribute("storage_filesystem_path")
+            
+            path_suffix = filesystem_path.removeprefix(path_prefix)
+            suballocations.append(path_suffix)
+          
+          output_lines = allocation_path + "|{" + ",".join(suballocations) + "}"
         
         self.stdout.write(output_lines)

--- a/coldfront/plugins/qumulo/management/commands/export_suballocation_psv.py
+++ b/coldfront/plugins/qumulo/management/commands/export_suballocation_psv.py
@@ -1,0 +1,30 @@
+from django.core.management.base import BaseCommand
+
+from coldfront.core.allocation.models import (
+    Allocation,
+    AllocationStatusChoice,
+    AllocationLinkage,
+)
+from coldfront.core.allocation.signals import allocation_activate
+
+
+class Command(BaseCommand):
+    help = "Assemble a psv of specified allocations and suballocations.  Intended to be used with the ACL parrallel reset script"
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--allocations",
+            nargs="+",
+            type=str,
+            required=True,
+            help="List parent allocation paths to use.  ",
+        )
+
+    def handle(self, *args, **options):
+        output_lines=[]
+        allocation_paths = options["allocations"]
+        
+        for allocation_path in allocation_paths:
+          output_lines = allocation_path + "|{}"
+        
+        self.stdout.write(output_lines)

--- a/coldfront/plugins/qumulo/management/commands/export_suballocation_psv.py
+++ b/coldfront/plugins/qumulo/management/commands/export_suballocation_psv.py
@@ -42,6 +42,6 @@ class Command(BaseCommand):
             path_suffix = filesystem_path.removeprefix(path_prefix)
             suballocations.append(path_suffix)
           
-          output_lines = allocation_path + "|{" + ",".join(suballocations) + "}"
+          output_lines.append(allocation_path + "|{" + ",".join(suballocations) + "}")
         
-        self.stdout.write(output_lines)
+        self.stdout.write("\n".join(output_lines))

--- a/coldfront/plugins/qumulo/management/commands/export_suballocation_psv.py
+++ b/coldfront/plugins/qumulo/management/commands/export_suballocation_psv.py
@@ -2,8 +2,10 @@ from django.core.management.base import BaseCommand
 
 from coldfront.core.allocation.models import (
     Allocation,
-    AllocationLinkage,AllocationAttributeType
+    AllocationLinkage,
+    AllocationAttributeType,
 )
+
 
 class Command(BaseCommand):
     help = "Assemble a psv of specified allocations and suballocations.  Intended to be used with the ACL parrallel reset script"
@@ -18,30 +20,39 @@ class Command(BaseCommand):
         )
 
     def handle(self, *args, **options):
-        output_lines=[]
+        output_lines = []
         allocation_paths = options["allocations"]
-        
+
         storage_filesystem_path_attribute_type = AllocationAttributeType.objects.get(
             name="storage_filesystem_path"
         )
-        
-        for allocation_path in allocation_paths:
-          suballocations = []
-          allocation = Allocation.objects.get(allocationattribute__allocation_attribute_type=storage_filesystem_path_attribute_type, allocationattribute__value=allocation_path)
-          
-          path_prefix = f"{allocation.get_attribute('storage_filesystem_path')}/Active/"
-          
-          try:
-            allocation_linkage_children = AllocationLinkage.objects.get(parent=allocation).children.all()
-          except AllocationLinkage.DoesNotExist:
-            allocation_linkage_children = []
 
-          for child_allocation in allocation_linkage_children:
-            filesystem_path: str = child_allocation.get_attribute("storage_filesystem_path")
-            
-            path_suffix = filesystem_path.removeprefix(path_prefix)
-            suballocations.append(path_suffix)
-          
-          output_lines.append(allocation_path + "|{" + ",".join(suballocations) + "}")
-        
+        for allocation_path in allocation_paths:
+            suballocations = []
+            allocation = Allocation.objects.get(
+                allocationattribute__allocation_attribute_type=storage_filesystem_path_attribute_type,
+                allocationattribute__value=allocation_path,
+            )
+
+            path_prefix = (
+                f"{allocation.get_attribute('storage_filesystem_path')}/Active/"
+            )
+
+            try:
+                allocation_linkage_children = AllocationLinkage.objects.get(
+                    parent=allocation
+                ).children.all()
+            except AllocationLinkage.DoesNotExist:
+                allocation_linkage_children = []
+
+            for child_allocation in allocation_linkage_children:
+                filesystem_path: str = child_allocation.get_attribute(
+                    "storage_filesystem_path"
+                )
+
+                path_suffix = filesystem_path.removeprefix(path_prefix)
+                suballocations.append(path_suffix)
+
+            output_lines.append(allocation_path + "|{" + ",".join(suballocations) + "}")
+
         self.stdout.write("\n".join(output_lines))

--- a/coldfront/plugins/qumulo/tests/management/commands/test_export_suballocation_psv.py
+++ b/coldfront/plugins/qumulo/tests/management/commands/test_export_suballocation_psv.py
@@ -1,0 +1,61 @@
+from django.test import TestCase,Client
+from django.contrib.auth.models import User
+from django.core.management import call_command
+
+from unittest.mock import patch, MagicMock
+
+from coldfront.core.project.models import Project
+from coldfront.plugins.qumulo.services.allocation_service import AllocationService
+from coldfront.plugins.qumulo.tests.utils.mock_data import (
+    build_models,default_form_data
+)
+
+from io import StringIO
+
+@patch("coldfront.plugins.qumulo.services.allocation_service.async_task")
+@patch("coldfront.plugins.qumulo.services.allocation_service.ActiveDirectoryAPI")
+@patch("coldfront.plugins.qumulo.tasks.ActiveDirectoryAPI")
+class TestExportSuballocationPsv(TestCase):
+  def setUp(self) -> None:
+      self.client = Client()
+
+      build_data = build_models()
+
+      self.project: Project = build_data["project"]
+      self.user: User = build_data["user"]
+
+      self.form_data = default_form_data.copy()
+      self.form_data["project_pk"] = self.project.id
+
+      self.client.force_login(self.user)
+
+      self.create_allocation = AllocationService.create_new_allocation
+
+      return super().setUp()
+    
+  def call_command(self, *args, **kwargs):
+        out = StringIO()
+        err = StringIO()
+        call_command(
+            # "my_custom_command",
+            *args,
+            stdout=out,
+            stderr=err,
+            **kwargs,
+        )
+        return out.getvalue(), err.getvalue()
+    
+  def test_single_parent_prints_expected_output(self,mock_active_directory_api: MagicMock,mock_allocation_view_AD: MagicMock,mock_allocation_view_async_task: MagicMock):
+    filesystem_path = "/storage3/fs1/foo"
+    self.form_data["storage_filesystem_path"] = filesystem_path
+    self.form_data["storage_type"] = "Storage3"
+    
+    self.create_allocation(user=self.user, form_data=self.form_data)[
+        "allocation"
+    ]
+    
+    out, err = self.call_command("export_suballocation_psv", "--allocations", filesystem_path)
+    
+    expected_output = filesystem_path + "|{}\n"
+    self.assertEqual(expected_output,out)
+    

--- a/coldfront/plugins/qumulo/tests/management/commands/test_export_suballocation_psv.py
+++ b/coldfront/plugins/qumulo/tests/management/commands/test_export_suballocation_psv.py
@@ -1,4 +1,7 @@
-from django.test import TestCase,Client
+import json
+import os
+
+from django.test import TestCase, Client
 from django.contrib.auth.models import User
 from django.core.management import call_command
 
@@ -7,55 +10,89 @@ from unittest.mock import patch, MagicMock
 from coldfront.core.project.models import Project
 from coldfront.plugins.qumulo.services.allocation_service import AllocationService
 from coldfront.plugins.qumulo.tests.utils.mock_data import (
-    build_models,default_form_data
+    build_models,
+    default_form_data,
+    mock_qumulo_info
 )
 
 from io import StringIO
 
+
 @patch("coldfront.plugins.qumulo.services.allocation_service.async_task")
 @patch("coldfront.plugins.qumulo.services.allocation_service.ActiveDirectoryAPI")
 @patch("coldfront.plugins.qumulo.tasks.ActiveDirectoryAPI")
+@patch.dict(os.environ, {"QUMULO_INFO": json.dumps(mock_qumulo_info)})
 class TestExportSuballocationPsv(TestCase):
-  def setUp(self) -> None:
-      self.client = Client()
+    def setUp(self) -> None:
+        self.client = Client()
 
-      build_data = build_models()
+        build_data = build_models()
 
-      self.project: Project = build_data["project"]
-      self.user: User = build_data["user"]
+        self.project: Project = build_data["project"]
+        self.user: User = build_data["user"]
 
-      self.form_data = default_form_data.copy()
-      self.form_data["project_pk"] = self.project.id
+        self.form_data = default_form_data.copy()
+        self.form_data["project_pk"] = self.project.id
 
-      self.client.force_login(self.user)
+        self.client.force_login(self.user)
 
-      self.create_allocation = AllocationService.create_new_allocation
+        self.create_allocation = AllocationService.create_new_allocation
 
-      return super().setUp()
-    
-  def call_command(self, *args, **kwargs):
+        return super().setUp()
+
+    def call_command(self, *args, **kwargs):
         out = StringIO()
         err = StringIO()
         call_command(
-            # "my_custom_command",
             *args,
             stdout=out,
             stderr=err,
             **kwargs,
         )
         return out.getvalue(), err.getvalue()
-    
-  def test_single_parent_prints_expected_output(self,mock_active_directory_api: MagicMock,mock_allocation_view_AD: MagicMock,mock_allocation_view_async_task: MagicMock):
-    filesystem_path = "/storage3/fs1/foo"
-    self.form_data["storage_filesystem_path"] = filesystem_path
-    self.form_data["storage_type"] = "Storage3"
-    
-    self.create_allocation(user=self.user, form_data=self.form_data)[
-        "allocation"
-    ]
-    
-    out, err = self.call_command("export_suballocation_psv", "--allocations", filesystem_path)
-    
-    expected_output = filesystem_path + "|{}\n"
-    self.assertEqual(expected_output,out)
-    
+
+    def test_single_parent_prints_expected_output(
+        self,
+        mock_active_directory_api: MagicMock,
+        mock_allocation_view_AD: MagicMock,
+        mock_allocation_view_async_task: MagicMock,
+    ):
+        self.form_data["storage_type"] = "Storage3"
+        filesystem_path = f"{mock_qumulo_info[self.form_data['storage_type']]['path']}/foo"
+        self.form_data["storage_filesystem_path"] = filesystem_path
+
+        self.create_allocation(user=self.user, form_data=self.form_data)["allocation"]
+
+        out, err = self.call_command(
+            "export_suballocation_psv", "--allocations", filesystem_path
+        )
+
+        expected_output = filesystem_path + "|{}\n"
+        
+        self.assertEqual(expected_output, out)
+
+    def test_single_parent_with_child(
+        self,
+        mock_active_directory_api: MagicMock,
+        mock_allocation_view_AD: MagicMock,
+        mock_allocation_view_async_task: MagicMock,
+    ):
+        self.form_data["storage_type"] = "Storage3"
+        filesystem_path = f"{mock_qumulo_info[self.form_data['storage_type']]['path']}/foo"
+        self.form_data["storage_filesystem_path"] = filesystem_path
+
+        allocation = self.create_allocation(user=self.user, form_data=self.form_data)["allocation"]
+        
+        suballocation_subpath = "bar"
+        suballocation_form_data = default_form_data.copy()
+        suballocation_form_data["storage_type"] = "Storage3"
+        suballocation_form_data["project_pk"] = self.project.id
+        suballocation_form_data["storage_filesystem_path"] = suballocation_subpath
+        
+        self.create_allocation(user=self.user, form_data=suballocation_form_data,parent_allocation=allocation)
+        out, err = self.call_command(
+            "export_suballocation_psv", "--allocations", filesystem_path
+        )
+
+        expected_output = filesystem_path + "|{" + suballocation_subpath + "}\n"
+        self.assertEqual(expected_output, out)

--- a/coldfront/plugins/qumulo/tests/management/commands/test_export_suballocation_psv.py
+++ b/coldfront/plugins/qumulo/tests/management/commands/test_export_suballocation_psv.py
@@ -12,7 +12,7 @@ from coldfront.plugins.qumulo.services.allocation_service import AllocationServi
 from coldfront.plugins.qumulo.tests.utils.mock_data import (
     build_models,
     default_form_data,
-    mock_qumulo_info
+    mock_qumulo_info,
 )
 
 from io import StringIO
@@ -58,7 +58,9 @@ class TestExportSuballocationPsv(TestCase):
         mock_allocation_view_async_task: MagicMock,
     ):
         self.form_data["storage_type"] = "Storage3"
-        filesystem_path = f"{mock_qumulo_info[self.form_data['storage_type']]['path']}/foo"
+        filesystem_path = (
+            f"{mock_qumulo_info[self.form_data['storage_type']]['path']}/foo"
+        )
         self.form_data["storage_filesystem_path"] = filesystem_path
 
         self.create_allocation(user=self.user, form_data=self.form_data)
@@ -68,7 +70,7 @@ class TestExportSuballocationPsv(TestCase):
         )
 
         expected_output = filesystem_path + "|{}\n"
-        
+
         self.assertEqual(expected_output, out)
 
     def test_single_parent_with_child(
@@ -78,79 +80,120 @@ class TestExportSuballocationPsv(TestCase):
         mock_allocation_view_async_task: MagicMock,
     ):
         self.form_data["storage_type"] = "Storage3"
-        filesystem_path = f"{mock_qumulo_info[self.form_data['storage_type']]['path']}/foo"
+        filesystem_path = (
+            f"{mock_qumulo_info[self.form_data['storage_type']]['path']}/foo"
+        )
         self.form_data["storage_filesystem_path"] = filesystem_path
 
-        allocation = self.create_allocation(user=self.user, form_data=self.form_data)["allocation"]
-        
+        allocation = self.create_allocation(user=self.user, form_data=self.form_data)[
+            "allocation"
+        ]
+
         suballocation_form_data = default_form_data.copy()
         suballocation_subpath = "bar"
         suballocation_form_data["storage_type"] = "Storage3"
         suballocation_form_data["project_pk"] = self.project.id
         suballocation_form_data["storage_filesystem_path"] = suballocation_subpath
-        
-        self.create_allocation(user=self.user, form_data=suballocation_form_data,parent_allocation=allocation)
-        
+
+        self.create_allocation(
+            user=self.user,
+            form_data=suballocation_form_data,
+            parent_allocation=allocation,
+        )
+
         out, err = self.call_command(
             "export_suballocation_psv", "--allocations", filesystem_path
         )
 
         expected_output = filesystem_path + "|{" + suballocation_subpath + "}\n"
         self.assertEqual(expected_output, out)
-        
-    def test_multiple_basic_allocations(self,
+
+    def test_multiple_basic_allocations(
+        self,
         mock_active_directory_api: MagicMock,
         mock_allocation_view_AD: MagicMock,
-        mock_allocation_view_async_task: MagicMock):
-      self.form_data["storage_type"] = "Storage3"
-      filesystem_path = f"{mock_qumulo_info[self.form_data['storage_type']]['path']}/foo"
-      self.form_data["storage_filesystem_path"] = filesystem_path
+        mock_allocation_view_async_task: MagicMock,
+    ):
+        self.form_data["storage_type"] = "Storage3"
+        filesystem_path = (
+            f"{mock_qumulo_info[self.form_data['storage_type']]['path']}/foo"
+        )
+        self.form_data["storage_filesystem_path"] = filesystem_path
 
-      self.create_allocation(user=self.user, form_data=self.form_data)
-      
-      allocation_2_form_data = default_form_data.copy()
-      allocation_2_form_data["project_pk"] = self.project.id
-      allocation2_filesystem_path = f"{mock_qumulo_info[allocation_2_form_data['storage_type']]['path']}/bar"
-      allocation_2_form_data["storage_filesystem_path"] = allocation2_filesystem_path
-      
-      self.create_allocation(user=self.user, form_data=allocation_2_form_data)
+        self.create_allocation(user=self.user, form_data=self.form_data)
 
-      out, err = self.call_command(
-          "export_suballocation_psv", "--allocations", filesystem_path, allocation2_filesystem_path
-      )
+        allocation_2_form_data = default_form_data.copy()
+        allocation_2_form_data["project_pk"] = self.project.id
+        allocation2_filesystem_path = (
+            f"{mock_qumulo_info[allocation_2_form_data['storage_type']]['path']}/bar"
+        )
+        allocation_2_form_data["storage_filesystem_path"] = allocation2_filesystem_path
 
-      expected_output = filesystem_path + "|{}\n" + allocation2_filesystem_path + "|{}\n"
-      
-      self.assertEqual(expected_output, out)
-      
-    def test_multiple_allocations(self,
+        self.create_allocation(user=self.user, form_data=allocation_2_form_data)
+
+        out, err = self.call_command(
+            "export_suballocation_psv",
+            "--allocations",
+            filesystem_path,
+            allocation2_filesystem_path,
+        )
+
+        expected_output = (
+            filesystem_path + "|{}\n" + allocation2_filesystem_path + "|{}\n"
+        )
+
+        self.assertEqual(expected_output, out)
+
+    def test_multiple_allocations(
+        self,
         mock_active_directory_api: MagicMock,
         mock_allocation_view_AD: MagicMock,
-        mock_allocation_view_async_task: MagicMock):
-      self.form_data["storage_type"] = "Storage3"
-      filesystem_path = f"{mock_qumulo_info[self.form_data['storage_type']]['path']}/foo"
-      self.form_data["storage_filesystem_path"] = filesystem_path
+        mock_allocation_view_async_task: MagicMock,
+    ):
+        self.form_data["storage_type"] = "Storage3"
+        filesystem_path = (
+            f"{mock_qumulo_info[self.form_data['storage_type']]['path']}/foo"
+        )
+        self.form_data["storage_filesystem_path"] = filesystem_path
 
-      self.create_allocation(user=self.user, form_data=self.form_data)
-      
-      allocation2_form_data = default_form_data.copy()
-      allocation2_form_data["project_pk"] = self.project.id
-      allocation2_filesystem_path = f"{mock_qumulo_info[allocation2_form_data['storage_type']]['path']}/bar"
-      allocation2_form_data["storage_filesystem_path"] = allocation2_filesystem_path
-      
-      allocation2 = self.create_allocation(user=self.user, form_data=allocation2_form_data)['allocation']
+        self.create_allocation(user=self.user, form_data=self.form_data)
 
-      suballocation_form_data = default_form_data.copy()
-      suballocation_subpath = "bah"
-      suballocation_form_data["project_pk"] = self.project.id
-      suballocation_form_data["storage_filesystem_path"] = suballocation_subpath
-      
-      self.create_allocation(user=self.user, form_data=suballocation_form_data,parent_allocation=allocation2)
+        allocation2_form_data = default_form_data.copy()
+        allocation2_form_data["project_pk"] = self.project.id
+        allocation2_filesystem_path = (
+            f"{mock_qumulo_info[allocation2_form_data['storage_type']]['path']}/bar"
+        )
+        allocation2_form_data["storage_filesystem_path"] = allocation2_filesystem_path
 
-      out, err = self.call_command(
-          "export_suballocation_psv", "--allocations", filesystem_path, allocation2_filesystem_path
-      )
+        allocation2 = self.create_allocation(
+            user=self.user, form_data=allocation2_form_data
+        )["allocation"]
 
-      expected_output = filesystem_path + "|{}\n" + allocation2_filesystem_path + "|{" + suballocation_subpath + "}\n"
-      
-      self.assertEqual(expected_output, out)
+        suballocation_form_data = default_form_data.copy()
+        suballocation_subpath = "bah"
+        suballocation_form_data["project_pk"] = self.project.id
+        suballocation_form_data["storage_filesystem_path"] = suballocation_subpath
+
+        self.create_allocation(
+            user=self.user,
+            form_data=suballocation_form_data,
+            parent_allocation=allocation2,
+        )
+
+        out, err = self.call_command(
+            "export_suballocation_psv",
+            "--allocations",
+            filesystem_path,
+            allocation2_filesystem_path,
+        )
+
+        expected_output = (
+            filesystem_path
+            + "|{}\n"
+            + allocation2_filesystem_path
+            + "|{"
+            + suballocation_subpath
+            + "}\n"
+        )
+
+        self.assertEqual(expected_output, out)

--- a/coldfront/plugins/qumulo/tests/management/commands/test_export_suballocation_psv.py
+++ b/coldfront/plugins/qumulo/tests/management/commands/test_export_suballocation_psv.py
@@ -61,7 +61,7 @@ class TestExportSuballocationPsv(TestCase):
         filesystem_path = f"{mock_qumulo_info[self.form_data['storage_type']]['path']}/foo"
         self.form_data["storage_filesystem_path"] = filesystem_path
 
-        self.create_allocation(user=self.user, form_data=self.form_data)["allocation"]
+        self.create_allocation(user=self.user, form_data=self.form_data)
 
         out, err = self.call_command(
             "export_suballocation_psv", "--allocations", filesystem_path
@@ -83,16 +83,74 @@ class TestExportSuballocationPsv(TestCase):
 
         allocation = self.create_allocation(user=self.user, form_data=self.form_data)["allocation"]
         
-        suballocation_subpath = "bar"
         suballocation_form_data = default_form_data.copy()
+        suballocation_subpath = "bar"
         suballocation_form_data["storage_type"] = "Storage3"
         suballocation_form_data["project_pk"] = self.project.id
         suballocation_form_data["storage_filesystem_path"] = suballocation_subpath
         
         self.create_allocation(user=self.user, form_data=suballocation_form_data,parent_allocation=allocation)
+        
         out, err = self.call_command(
             "export_suballocation_psv", "--allocations", filesystem_path
         )
 
         expected_output = filesystem_path + "|{" + suballocation_subpath + "}\n"
         self.assertEqual(expected_output, out)
+        
+    def test_multiple_basic_allocations(self,
+        mock_active_directory_api: MagicMock,
+        mock_allocation_view_AD: MagicMock,
+        mock_allocation_view_async_task: MagicMock):
+      self.form_data["storage_type"] = "Storage3"
+      filesystem_path = f"{mock_qumulo_info[self.form_data['storage_type']]['path']}/foo"
+      self.form_data["storage_filesystem_path"] = filesystem_path
+
+      self.create_allocation(user=self.user, form_data=self.form_data)
+      
+      allocation_2_form_data = default_form_data.copy()
+      allocation_2_form_data["project_pk"] = self.project.id
+      allocation2_filesystem_path = f"{mock_qumulo_info[allocation_2_form_data['storage_type']]['path']}/bar"
+      allocation_2_form_data["storage_filesystem_path"] = allocation2_filesystem_path
+      
+      self.create_allocation(user=self.user, form_data=allocation_2_form_data)
+
+      out, err = self.call_command(
+          "export_suballocation_psv", "--allocations", filesystem_path, allocation2_filesystem_path
+      )
+
+      expected_output = filesystem_path + "|{}\n" + allocation2_filesystem_path + "|{}\n"
+      
+      self.assertEqual(expected_output, out)
+      
+    def test_multiple_allocations(self,
+        mock_active_directory_api: MagicMock,
+        mock_allocation_view_AD: MagicMock,
+        mock_allocation_view_async_task: MagicMock):
+      self.form_data["storage_type"] = "Storage3"
+      filesystem_path = f"{mock_qumulo_info[self.form_data['storage_type']]['path']}/foo"
+      self.form_data["storage_filesystem_path"] = filesystem_path
+
+      self.create_allocation(user=self.user, form_data=self.form_data)
+      
+      allocation2_form_data = default_form_data.copy()
+      allocation2_form_data["project_pk"] = self.project.id
+      allocation2_filesystem_path = f"{mock_qumulo_info[allocation2_form_data['storage_type']]['path']}/bar"
+      allocation2_form_data["storage_filesystem_path"] = allocation2_filesystem_path
+      
+      allocation2 = self.create_allocation(user=self.user, form_data=allocation2_form_data)['allocation']
+
+      suballocation_form_data = default_form_data.copy()
+      suballocation_subpath = "bah"
+      suballocation_form_data["project_pk"] = self.project.id
+      suballocation_form_data["storage_filesystem_path"] = suballocation_subpath
+      
+      self.create_allocation(user=self.user, form_data=suballocation_form_data,parent_allocation=allocation2)
+
+      out, err = self.call_command(
+          "export_suballocation_psv", "--allocations", filesystem_path, allocation2_filesystem_path
+      )
+
+      expected_output = filesystem_path + "|{}\n" + allocation2_filesystem_path + "|{" + suballocation_subpath + "}\n"
+      
+      self.assertEqual(expected_output, out)


### PR DESCRIPTION
This will take in the filesystem paths of allocations and print out the needed output for the slurm acl resetter script, including suballocations