### PR TITLE
Feature/itdev 38344/subdir to suballocation

### DIFF
--- a/coldfront/core/allocation/views.py
+++ b/coldfront/core/allocation/views.py
@@ -61,7 +61,8 @@ from coldfront.core.project.models import (Project, ProjectUser, ProjectPermissi
 from coldfront.core.resource.models import Resource
 from coldfront.core.utils.common import get_domain_url, import_from_settings
 from coldfront.core.utils.mail import send_allocation_admin_email, send_allocation_customer_email, send_email_template, build_link
-
+from coldfront.plugins.qumulo.utils.qumulo_api import AllocationDirectoryError
+from coldfront.plugins.qumulo.signals import AllocationActivationWarning
 ALLOCATION_ENABLE_ALLOCATION_RENEWAL = import_from_settings(
     'ALLOCATION_ENABLE_ALLOCATION_RENEWAL', True)
 ALLOCATION_DEFAULT_ALLOCATION_LENGTH = import_from_settings(
@@ -222,15 +223,24 @@ class AllocationDetailView(LoginRequiredMixin, UserPassesTestMixin, TemplateView
 
             allocation_obj.save()
 
-            allocation_activate.send(
-                sender=self.__class__, allocation_pk=allocation_obj.pk)
+            activation_warnings = False
+            try:
+                allocation_activate.send(
+                    sender=self.__class__, allocation_pk=allocation_obj.pk)
+            except AllocationActivationWarning as aaw:
+                messages.warning(request, str(aaw))
+                activation_warnings = True
+            except AllocationDirectoryError as ade:
+                messages.error(request, str(ade))
+                return HttpResponseRedirect(reverse('allocation-detail', kwargs={'pk': pk}))
+
             allocation_users = allocation_obj.allocationuser_set.exclude(status__name__in=['Removed', 'Error'])
             for allocation_user in allocation_users:
                 allocation_activate_user.send(
                     sender=self.__class__, allocation_user_pk=allocation_user.pk)
 
             # send_allocation_customer_email(allocation_obj, 'Allocation Activated', 'email/allocation_activated.txt', domain_url=get_domain_url(self.request))
-            if action != 'auto-approve':
+            if action != 'auto-approve' and not activation_warnings:
                 messages.success(request, 'Allocation Activated!')
 
         elif old_status != allocation_obj.status.name in ['Denied', 'New', 'Revoked']:

--- a/coldfront/core/allocation/views.py
+++ b/coldfront/core/allocation/views.py
@@ -61,7 +61,6 @@ from coldfront.core.project.models import (Project, ProjectUser, ProjectPermissi
 from coldfront.core.resource.models import Resource
 from coldfront.core.utils.common import get_domain_url, import_from_settings
 from coldfront.core.utils.mail import send_allocation_admin_email, send_allocation_customer_email, send_email_template, build_link
-from coldfront.plugins.qumulo.utils.qumulo_api import AllocationDirectoryError
 from coldfront.plugins.qumulo.signals import AllocationActivationWarning
 ALLOCATION_ENABLE_ALLOCATION_RENEWAL = import_from_settings(
     'ALLOCATION_ENABLE_ALLOCATION_RENEWAL', True)
@@ -230,9 +229,6 @@ class AllocationDetailView(LoginRequiredMixin, UserPassesTestMixin, TemplateView
             except AllocationActivationWarning as aaw:
                 messages.warning(request, str(aaw))
                 activation_warnings = True
-            except AllocationDirectoryError as ade:
-                messages.error(request, str(ade))
-                return HttpResponseRedirect(reverse('allocation-detail', kwargs={'pk': pk}))
 
             allocation_users = allocation_obj.allocationuser_set.exclude(status__name__in=['Removed', 'Error'])
             for allocation_user in allocation_users:

--- a/coldfront/plugins/qumulo/management/commands/activate_storage_allocations.py
+++ b/coldfront/plugins/qumulo/management/commands/activate_storage_allocations.py
@@ -82,4 +82,6 @@ class Command(BaseCommand):
         allocation.status = AllocationStatusChoice.objects.get(name="Active")
         allocation.save()
 
+        # bmulligan 20260519: the send_robust() function could be of use here,
+        # but maybe reconsider using signals at all in this spot.
         allocation_activate.send(sender=self.__class__, allocation_pk=allocation.pk)

--- a/coldfront/plugins/qumulo/signals.py
+++ b/coldfront/plugins/qumulo/signals.py
@@ -4,7 +4,10 @@ from django_q.tasks import async_task
 import logging
 import json
 
-from coldfront.plugins.qumulo.utils.qumulo_api import QumuloAPI
+from coldfront.plugins.qumulo.utils.qumulo_api import (
+        AllocationDirectoryError,
+        QumuloAPI
+)
 from coldfront.plugins.qumulo.utils.storage_controller import StorageControllerFactory
 from coldfront.plugins.qumulo.utils.acl_allocations import AclAllocations
 from coldfront.plugins.qumulo.utils.update_user_data import (
@@ -26,6 +29,8 @@ from coldfront.core.allocation.signals import (
 from django.contrib.auth.models import User
 from django.db.models.signals import post_save
 
+class AllocationActivationWarning(Exception):
+    pass
 
 @receiver(post_save, sender=User)
 def on_allocation_save_retrieve_additional_user_data(
@@ -59,9 +64,13 @@ def on_allocation_activate(sender, **kwargs):
             name=name,
             limit_in_bytes=limit_in_bytes,
         )
+    except ValueError:
+        logger.warn("Can't create allocation: Some attributes are missing or invalid")
+    except AllocationDirectoryError:
+        raise
 
+    try:
         qumulo_api.setup_allocation(fs_path)
-
     except ValueError:
         logger.warn("Can't create allocation: Some attributes are missing or invalid")
 
@@ -77,6 +86,9 @@ def on_allocation_activate(sender, **kwargs):
         False,
         q_options={"retry": 90000, "timeout": 86400},
     )
+
+    if qumulo_api.create_allocation_message:
+        raise AllocationActivationWarning(qumulo_api.create_allocation_message)
 
 
 @receiver(allocation_disable)

--- a/coldfront/plugins/qumulo/signals.py
+++ b/coldfront/plugins/qumulo/signals.py
@@ -4,10 +4,7 @@ from django_q.tasks import async_task
 import logging
 import json
 
-from coldfront.plugins.qumulo.utils.qumulo_api import (
-        AllocationDirectoryError,
-        QumuloAPI
-)
+from coldfront.plugins.qumulo.utils.qumulo_api import QumuloAPI
 from coldfront.plugins.qumulo.utils.storage_controller import StorageControllerFactory
 from coldfront.plugins.qumulo.utils.acl_allocations import AclAllocations
 from coldfront.plugins.qumulo.utils.update_user_data import (
@@ -66,8 +63,6 @@ def on_allocation_activate(sender, **kwargs):
         )
     except ValueError:
         logger.warn("Can't create allocation: Some attributes are missing or invalid")
-    except AllocationDirectoryError:
-        raise
 
     try:
         qumulo_api.setup_allocation(fs_path)

--- a/coldfront/plugins/qumulo/tests/test_signals.py
+++ b/coldfront/plugins/qumulo/tests/test_signals.py
@@ -90,6 +90,7 @@ class TestSignals(TestCase):
     ):
         qumulo_instance = MagicMock()
         qumulo_instance.create_allocation = MagicMock()
+        qumulo_instance.create_allocation_message = None
         mock_create_connection.return_value = qumulo_instance
         allocation_activate.send(
             sender=self.__class__, allocation_pk=self.storage_allocation.pk

--- a/coldfront/plugins/qumulo/tests/test_signals.py
+++ b/coldfront/plugins/qumulo/tests/test_signals.py
@@ -118,6 +118,7 @@ class TestSignals(TestCase):
     ):
         qumulo_instance = MagicMock()
         qumulo_instance.create_allocation = MagicMock(side_effect=ValueError())
+        qumulo_instance.create_allocation_message = None
         mock_create_connection.return_value = qumulo_instance
 
         allocation_activate.send(

--- a/coldfront/plugins/qumulo/utils/aces_manager.py
+++ b/coldfront/plugins/qumulo/utils/aces_manager.py
@@ -545,7 +545,7 @@ class AcesManager(object):
 
     @staticmethod
     def normalize_trustee(trustee: dict):
-        if "name" not in trustee:
+        if trustee.get("name", None) == None:
             return trustee
         domain = None
         name = trustee["name"].replace("ACCOUNTS\\", "").lower()

--- a/coldfront/plugins/qumulo/utils/qumulo_api.py
+++ b/coldfront/plugins/qumulo/utils/qumulo_api.py
@@ -18,9 +18,6 @@ from pathlib import PurePath
 
 load_dotenv(override=True)
 
-class AllocationDirectoryError(Exception):
-    pass
-
 class QumuloAPI:
     def __init__(self, connection_info: Dict[str, str]) -> None:
         self.host = connection_info["host"]
@@ -69,13 +66,6 @@ class QumuloAPI:
             self.create_allocation_message = (
                 'WARNING: The allocation was created with an existing path: '
                 f'{fs_path}'
-            )
-        elif is_parent_allocation:
-            raise AllocationDirectoryError(
-                (
-                    f'ERROR: The path {fs_path} already exists.  Allocation '
-                    'creation cannot proceed.'
-                )
             )
 
         self.validate_protocols(protocols)

--- a/coldfront/plugins/qumulo/utils/qumulo_api.py
+++ b/coldfront/plugins/qumulo/utils/qumulo_api.py
@@ -39,6 +39,8 @@ class QumuloAPI:
         name: str,
         limit_in_bytes: int,
     ):
+        # bmulligan 20260519: the "name" parameter is required above and
+        # validated below, but unused before it gets re-assigned
 
         if name == None:
             raise ValueError("name must be defined.")
@@ -50,6 +52,7 @@ class QumuloAPI:
             protocols = []
 
         dir_path = str(PurePath(fs_path).parent)
+        # bmulligan 20260519: this overwrites "name" before it gets used.
         name = str(PurePath(fs_path).name)
 
         directory_exists = True

--- a/coldfront/plugins/qumulo/utils/qumulo_api.py
+++ b/coldfront/plugins/qumulo/utils/qumulo_api.py
@@ -18,6 +18,8 @@ from pathlib import PurePath
 
 load_dotenv(override=True)
 
+class AllocationDirectoryError(Exception):
+    pass
 
 class QumuloAPI:
     def __init__(self, connection_info: Dict[str, str]) -> None:
@@ -25,6 +27,7 @@ class QumuloAPI:
         self.port = connection_info["port"]
         self.username = connection_info["user"]
         self.password = connection_info["pass"]
+        self.create_allocation_message = None
         self.rc: RestClient = RestClient(self.host, self.port)
         self.rc.login(self.username, self.password)
         self.valid_protocols = list(
@@ -51,7 +54,29 @@ class QumuloAPI:
 
         dir_path = str(PurePath(fs_path).parent)
         name = str(PurePath(fs_path).name)
-        self.rc.fs.create_directory(dir_path=dir_path, name=name)
+
+        directory_exists = True
+        is_parent_allocation = QumuloAPI.is_allocation_root_path(fs_path)
+        try:
+            file_attr = self.rc.fs.get_file_attr(path=fs_path)
+        except RequestError as e:
+            if e.status_code == 404:
+                directory_exists = False
+
+        if not directory_exists:
+            self.rc.fs.create_directory(dir_path=dir_path, name=name)
+        elif not is_parent_allocation:
+            self.create_allocation_message = (
+                'WARNING: The allocation was created with an existing path: '
+                f'{fs_path}'
+            )
+        elif is_parent_allocation:
+            raise AllocationDirectoryError(
+                (
+                    f'ERROR: The path {fs_path} already exists.  Allocation '
+                    'creation cannot proceed.'
+                )
+            )
 
         self.validate_protocols(protocols)
 


### PR DESCRIPTION
Testing instructions:

1. Create a parent allocation, likely in `storage2-dev` or use a pre-existing one that can be modified.
2. Within the parent allocation, create a directory that will be used for the sub-allocation.
3. In Coldfront, create a sub-allocation in the parent with the filesystem path of the directory created in step 2.
4. Activate the sub-allocation when it is available in the "Allocation Requests" screen and observe the warning message printed, which should be of the format: `WARNING: The allocation was created with an existing path: [existing path]`.
5. Optionally check that all related activation tasks (allocation setup, ACL reset, etc.) have successfully completed.